### PR TITLE
Add build_projector function with ridge, diagnostics, and tests

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,3 +6,4 @@ export(make_spmat_triplet)
 export(spmat_dense_prod)
 
 export(make_trialwise_X)
+export(build_projector)

--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -1,0 +1,43 @@
+#' Build projector components from design matrix
+#'
+#' Perform a sparse QR decomposition of the trial-wise design matrix and
+#' optionally construct a ridge-regularized projector.
+#'
+#' @param X_theta Sparse design matrix from \code{make_trialwise_X()}.
+#' @param lambda_global Non-negative ridge regularization parameter.
+#' @param diagnostics Logical; attach timing and condition number.
+#'
+#' @return An object of class \code{fr_projector} containing \code{Qt},
+#'   \code{R} and \code{K_global} if requested.
+#' @export
+build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE) {
+  start_time <- proc.time()["elapsed"]
+
+  qr_obj <- Matrix::qr(X_theta)
+  Qt <- t(Matrix::qr.Q(qr_obj))
+  R <- Matrix::qr.R(qr_obj)
+
+  cond_R <- kappa(R)
+  if (is.finite(cond_R) && cond_R > 1e6) {
+    warning("High collinearity detected in design matrix: cond(R) > 1e6")
+  }
+
+  if (lambda_global > 0) {
+    m <- ncol(R)
+    K_global <- solve(crossprod(R) + diag(lambda_global, m), t(R) %*% Qt)
+  } else {
+    K_global <- Qt
+  }
+
+  build_time <- proc.time()["elapsed"] - start_time
+  diag_list <- NULL
+  if (diagnostics) {
+    diag_list <- list(cond_R = as.numeric(cond_R),
+                      lambda_global_used = lambda_global,
+                      build_time = build_time)
+  }
+
+  out <- fr_projector(Qt, R, K_global)
+  attr(out, "diagnostics") <- diag_list
+  out
+}

--- a/tests/testthat/test-build-projector.R
+++ b/tests/testthat/test-build-projector.R
@@ -1,0 +1,43 @@
+context("build_projector")
+
+test_that("build_projector sparse QR works", {
+  em <- list(onsets = c(0L, 2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  X <- make_trialwise_X(em, hrf_basis_matrix = basis)$X
+  proj <- build_projector(X)
+  qr_obj <- qr(X)
+  Qt_exp <- t(qr.Q(qr_obj))
+  R_exp <- qr.R(qr_obj)
+  expect_equal(proj$Qt, Qt_exp)
+  expect_equal(proj$R, R_exp)
+})
+
+test_that("build_projector applies ridge", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  X <- make_trialwise_X(em, hrf_basis_matrix = basis)$X
+  lambda <- 0.5
+  proj <- build_projector(X, lambda_global = lambda)
+  qr_obj <- qr(X)
+  Qt <- t(qr.Q(qr_obj))
+  R <- qr.R(qr_obj)
+  K_exp <- solve(crossprod(R) + diag(lambda, ncol(R)), t(R) %*% Qt)
+  expect_equal(proj$K_global, K_exp)
+})
+
+test_that("build_projector diagnostics", {
+  em <- list(onsets = c(0L), n_time = 2L)
+  basis <- matrix(1, nrow = 1, ncol = 1)
+  X <- make_trialwise_X(em, hrf_basis_matrix = basis)$X
+  proj <- build_projector(X, diagnostics = TRUE)
+  diag <- attr(proj, "diagnostics")
+  expect_true(!is.null(diag))
+  expect_equal(diag$cond_R, kappa(proj$R))
+})
+
+test_that("build_projector warns on high condition number", {
+  X <- Matrix::Matrix(matrix(c(1,1,1,1), 2, 2), sparse = TRUE)
+  expect_warning(build_projector(X))
+})


### PR DESCRIPTION
## Summary
- implement `build_projector()` for sparse QR decompositions
- support optional global ridge regularization
- compute condition number for `R` and warn on high collinearity
- expose `build_projector()` in NAMESPACE
- add unit tests for projector construction

## Testing
- `R CMD check` *(fails: R not installed)*