### PR TITLE
Implement adaptive lambda methods and PC collapse

### DIFF
--- a/R/adaptive_ridge_projector.R
+++ b/R/adaptive_ridge_projector.R
@@ -1,14 +1,18 @@
 #' Adaptive Ridge Projection for a Searchlight
 #'
 #' Computes a ridge-regularized projector for a searchlight's BOLD data using
-#' components from `build_projector()`. Only `lambda_adaptive_method = "none"`
-#' is currently implemented.
+#' components from `build_projector()`. Supports empirical Bayes ("EB") and
+#' simple cross-validated ("LOOcv_local") selection of the ridge parameter in
+#' addition to the default "none" method.
 #'
 #' @param Y_sl Matrix of BOLD data for the searchlight (T x V_sl).
 #' @param projector_components Object returned by `build_projector()`.
 #' @param lambda_adaptive_method Method for choosing searchlight-specific lambda.
 #'   Defaults to "none" which simply uses `lambda_floor_global`.
 #' @param lambda_floor_global Minimum ridge penalty to apply.
+#' @param X_theta_for_EB_residuals Optional design matrix `X(θ)` used for
+#'   computing residuals when `lambda_adaptive_method = "EB"` or when
+#'   cross-validating local lambda.
 #' @param diagnostics Logical; return diagnostic information.
 #' @return A list with elements:
 #'   \item{Z_sl_raw}{Projected coefficients ((N*K) x V_sl).}
@@ -18,14 +22,59 @@ adaptive_ridge_projector <- function(Y_sl,
                                      projector_components,
                                      lambda_adaptive_method = "none",
                                      lambda_floor_global = 0,
+                                     X_theta_for_EB_residuals = NULL,
                                      diagnostics = FALSE) {
   Qt <- projector_components$Qt
   R <- projector_components$R
 
+  lambda_sl_raw <- NA
+  s_n_sq <- NA
+  s_b_sq <- NA
+
   if (lambda_adaptive_method == "none") {
     lambda_eff <- lambda_floor_global
+  } else if (lambda_adaptive_method == "EB") {
+    if (is.null(X_theta_for_EB_residuals)) {
+      stop("X_theta_for_EB_residuals must be provided for EB method")
+    }
+    beta_ols <- solve(R, Qt %*% Y_sl)
+    resid_mat <- Y_sl - X_theta_for_EB_residuals %*% beta_ols
+    T_obs <- nrow(Y_sl)
+    V_sl <- ncol(Y_sl)
+    m <- ncol(R)
+    s_n_sq <- sum(resid_mat^2) / ((T_obs - m) * V_sl)
+    s_b_sq <- sum(beta_ols^2) / (m * V_sl)
+    lambda_sl_raw <- s_n_sq / s_b_sq
+    lambda_eff <- max(lambda_floor_global, lambda_sl_raw)
+  } else if (lambda_adaptive_method == "LOOcv_local") {
+    if (is.null(X_theta_for_EB_residuals)) {
+      stop("X_theta_for_EB_residuals must be provided for LOOcv_local")
+    }
+    X <- X_theta_for_EB_residuals
+    T_obs <- nrow(X)
+    folds <- rep_len(seq_len(min(4L, T_obs)), T_obs)
+    lambda_grid <- c(0, 0.1, 1, 10) + lambda_floor_global
+    cv_err <- numeric(length(lambda_grid))
+    for (i in seq_along(lambda_grid)) {
+      lam <- lambda_grid[i]
+      err <- 0
+      for (f in unique(folds)) {
+        idx_te <- which(folds == f)
+        idx_tr <- setdiff(seq_len(T_obs), idx_te)
+        qr_tr <- qr(X[idx_tr, , drop = FALSE])
+        Qt_tr <- t(qr.Q(qr_tr))
+        R_tr <- qr.R(qr_tr)
+        beta_tr <- solve(crossprod(R_tr) + diag(lam, ncol(R_tr)),
+                         t(R_tr) %*% Qt_tr %*% Y_sl[idx_tr, , drop = FALSE])
+        pred <- X[idx_te, , drop = FALSE] %*% beta_tr
+        err <- err + sum((Y_sl[idx_te, , drop = FALSE] - pred)^2)
+      }
+      cv_err[i] <- err
+    }
+    lambda_sl_raw <- lambda_grid[which.min(cv_err)]
+    lambda_eff <- max(lambda_floor_global, lambda_sl_raw)
   } else {
-    stop("Only lambda_adaptive_method = 'none' is implemented")
+    stop("Unknown lambda_adaptive_method")
   }
 
   m <- ncol(R)
@@ -36,7 +85,10 @@ adaptive_ridge_projector <- function(Y_sl,
 
   diag_list <- NULL
   if (diagnostics) {
-    diag_list <- list(lambda_sl_chosen = lambda_eff)
+    diag_list <- list(lambda_sl_chosen = lambda_eff,
+                      lambda_sl_raw = lambda_sl_raw,
+                      s_n_sq = s_n_sq,
+                      s_b_sq = s_b_sq)
   }
 
   list(Z_sl_raw = Z_sl_raw, diag_data = diag_list)

--- a/R/collapse_beta.R
+++ b/R/collapse_beta.R
@@ -1,14 +1,14 @@
 #' Collapse Projected Betas Across HRF Bases
 #'
 #' Collapses the raw projected coefficients `Z_sl_raw` into trial-wise
-#' feature patterns. Currently only `method = "rss"` (root-sum-square)
-#' is implemented.
+#' feature patterns. Supports the default root-sum-square (`method = "rss"`)
+#' collapse and an SNR-optimal principal component (`method = "pc"`).
 #'
 #' @param Z_sl_raw Matrix of raw projected coefficients with
 #'   `(N_trials * K_hrf_bases)` rows and `V_sl` columns.
 #' @param N_trials Number of trials.
 #' @param K_hrf_bases Number of HRF basis functions used.
-#' @param method Collapse method. Only "rss" is implemented.
+#' @param method Collapse method. Either "rss" or "pc".
 #' @param diagnostics Logical; return diagnostic information.
 #' @return A list with elements:
 #'   \item{A_sl}{Collapsed trial pattern matrix `N_trials x V_sl`.}
@@ -17,8 +17,8 @@
 #' @export
 collapse_beta <- function(Z_sl_raw, N_trials, K_hrf_bases,
                           method = "rss", diagnostics = FALSE) {
-  if (method != "rss") {
-    stop("Only method = 'rss' is implemented")
+  if (!method %in% c("rss", "pc")) {
+    stop("method must be either 'rss' or 'pc'")
   }
 
   if (nrow(Z_sl_raw) != N_trials * K_hrf_bases) {
@@ -27,16 +27,33 @@ collapse_beta <- function(Z_sl_raw, N_trials, K_hrf_bases,
 
   V_sl <- ncol(Z_sl_raw)
   A_sl <- matrix(0, nrow = N_trials, ncol = V_sl)
+  w_sl <- NULL
 
-  for (n in seq_len(N_trials)) {
-    rows <- ((n - 1) * K_hrf_bases + 1):(n * K_hrf_bases)
-    A_sl[n, ] <- sqrt(colSums(Z_sl_raw[rows, , drop = FALSE]^2))
+  if (method == "rss") {
+    for (n in seq_len(N_trials)) {
+      rows <- ((n - 1) * K_hrf_bases + 1):(n * K_hrf_bases)
+      A_sl[n, ] <- sqrt(colSums(Z_sl_raw[rows, , drop = FALSE]^2))
+    }
+  } else if (method == "pc") {
+    Z_stack <- matrix(0, nrow = N_trials * V_sl, ncol = K_hrf_bases)
+    for (n in seq_len(N_trials)) {
+      rows <- ((n - 1) * K_hrf_bases + 1):(n * K_hrf_bases)
+      Z_stack[((n - 1) * V_sl + 1):(n * V_sl), ] <- t(Z_sl_raw[rows, , drop = FALSE])
+    }
+    C_z <- crossprod(Z_stack) / (nrow(Z_stack) - 1)
+    eig <- eigen(C_z)
+    w_sl <- eig$vectors[, 1]
+    w_sl <- w_sl / sqrt(sum(w_sl^2))
+    for (n in seq_len(N_trials)) {
+      rows <- ((n - 1) * K_hrf_bases + 1):(n * K_hrf_bases)
+      A_sl[n, ] <- crossprod(w_sl, Z_sl_raw[rows, , drop = FALSE])
+    }
   }
 
   diag_list <- NULL
   if (diagnostics) {
-    diag_list <- list()
+    diag_list <- list(method = method, w_sl = w_sl)
   }
 
-  list(A_sl = A_sl, w_sl = NULL, diag_data = diag_list)
+  list(A_sl = A_sl, w_sl = w_sl, diag_data = diag_list)
 }

--- a/tests/testthat/test-adaptive-collapse.R
+++ b/tests/testthat/test-adaptive-collapse.R
@@ -25,3 +25,52 @@ test_that("collapse_beta rss works", {
   expected <- c(sqrt(1^2 + 2^2), sqrt(3^2 + 4^2))
   expect_equal(as.numeric(A_sl[,1]), expected)
 })
+
+test_that("adaptive_ridge_projector EB works", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  X_obj <- make_trialwise_X(em, hrf_basis_matrix = basis)
+  X <- as.matrix(X_obj$X)
+  proj <- build_projector(X)
+  Y_sl <- matrix(rnorm(12), nrow = 6, ncol = 2)
+  res <- adaptive_ridge_projector(Y_sl, proj,
+                                  lambda_adaptive_method = "EB",
+                                  lambda_floor_global = 0.1,
+                                  X_theta_for_EB_residuals = X,
+                                  diagnostics = TRUE)
+  expect_equal(dim(res$Z_sl_raw), c(ncol(X), 2L))
+  diag <- res$diag_data
+  expect_true(!is.null(diag))
+  expect_true(is.finite(diag$lambda_sl_chosen))
+  expect_true(is.finite(diag$s_n_sq))
+  expect_true(is.finite(diag$s_b_sq))
+})
+
+test_that("adaptive_ridge_projector LOOcv_local works", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  X_obj <- make_trialwise_X(em, hrf_basis_matrix = basis)
+  X <- as.matrix(X_obj$X)
+  proj <- build_projector(X)
+  Y_sl <- matrix(rnorm(12), nrow = 6, ncol = 2)
+  res <- adaptive_ridge_projector(Y_sl, proj,
+                                  lambda_adaptive_method = "LOOcv_local",
+                                  lambda_floor_global = 0.1,
+                                  X_theta_for_EB_residuals = X,
+                                  diagnostics = TRUE)
+  expect_equal(dim(res$Z_sl_raw), c(ncol(X), 2L))
+  expect_true(is.finite(res$diag_data$lambda_sl_chosen))
+})
+
+test_that("collapse_beta pc works", {
+  N_trials <- 2
+  K <- 2
+  Z_sl_raw <- matrix(c(1,2,3,4), nrow = N_trials*K, ncol = 1)
+  res <- collapse_beta(Z_sl_raw, N_trials, K, method = "pc", diagnostics = TRUE)
+  expect_equal(length(res$w_sl), K)
+  expect_equal(dim(res$A_sl), c(N_trials,1))
+  expect_equal(res$diag_data$w_sl, res$w_sl)
+})
+


### PR DESCRIPTION
## Summary
- extend `adaptive_ridge_projector()` with Empirical Bayes and CV methods
- add PC-based beta collapse in `collapse_beta()`
- improve diagnostics for layers 2 & 3
- unit tests for new lambda methods and collapse option

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*