### PR TITLE
Implement projected searchlight pipeline with diagnostics

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -9,3 +9,7 @@ export(make_trialwise_X)
 export(build_projector)
 export(adaptive_ridge_projector)
 export(collapse_beta)
+
+export(mvpa_projected_searchlight)
+export(combine_projection_diagnostics)
+export(explain_projection_results)

--- a/R/combine_projection_diagnostics.R
+++ b/R/combine_projection_diagnostics.R
@@ -1,0 +1,21 @@
+#' Combine projection diagnostics from searchlight runs
+#'
+#' Simple helper intended for use as the `.combine` function in
+#' `rMVPA::searchlight`. It collects the searchlight-specific diagnostic
+#' information (currently `lambda_sl` and `w_sl`) from each call.
+#'
+#' @param x Accumulated results.
+#' @param y New searchlight result to combine.
+#'
+#' @return A list with `results` (all searchlight outputs) and `diagnostics`,
+#'   a list of per-searchlight diagnostic entries.
+#' @export
+combine_projection_diagnostics <- function(x, y) {
+  if (is.null(x)) {
+    return(list(results = list(y),
+                diagnostics = list(y$diag_data)))
+  }
+  x$results <- c(x$results, list(y))
+  x$diagnostics <- c(x$diagnostics, list(y$diag_data))
+  x
+}

--- a/R/explain_projection_results.R
+++ b/R/explain_projection_results.R
@@ -1,0 +1,22 @@
+#' Create NIfTI map of searchlight diagnostics
+#'
+#' This function extracts the chosen searchlight ridge penalties (`lambda_sl`)
+#' from the output of `combine_projection_diagnostics` and returns a NIfTI-like
+#' array for visualization.
+#'
+#' @param sl_results Result object from `combine_projection_diagnostics` that
+#'   contains a `diagnostics` list.
+#' @param mask_dims Numeric vector giving the dimensions of the brain mask.
+#'
+#' @return An array of dimension `mask_dims` containing the `lambda_sl` values.
+#'   In a full implementation this would return a `neuroim2` NIfTI object.
+#' @export
+explain_projection_results <- function(sl_results, mask_dims) {
+  if (is.null(sl_results$diagnostics)) {
+    stop("No diagnostics found in searchlight results")
+  }
+  lambda_vec <- vapply(sl_results$diagnostics,
+                       function(d) d$lambda_sl,
+                       numeric(1))
+  array(lambda_vec, dim = mask_dims)
+}

--- a/R/mvpa_projected_searchlight.R
+++ b/R/mvpa_projected_searchlight.R
@@ -1,0 +1,94 @@
+#' Run projected MVPA searchlight (placeholder)
+#'
+#' Constructs the trial-wise design matrix, builds global projector components,
+#' and prepares a searchlight function that applies adaptive ridge projection and
+#' beta collapse. If the `rMVPA` package is installed, this function will call
+#' `rMVPA::searchlight` with the prepared function. Otherwise a list containing
+#' the components and searchlight function is returned.
+#'
+#' @param Y BOLD data matrix (time points x voxels).
+#' @param event_model List describing the experimental events passed to
+#'   \code{make_trialwise_X}.
+#' @param hrf_basis_func Optional HRF basis generating function.
+#' @param theta_params Optional parameters for \code{hrf_basis_func}.
+#' @param hrf_basis_matrix Optional pre-computed HRF basis matrix.
+#' @param lambda_global Global ridge penalty.
+#' @param lambda_adaptive_method Method for searchlight-specific lambda.
+#' @param collapse_method Method for \code{collapse_beta}.
+#' @param diagnostics Logical; return diagnostic information.
+#' @param ... Additional arguments passed to \code{rMVPA::searchlight} when that
+#'   package is available.
+#'
+#' @return If \code{rMVPA} is installed, the result of
+#'   \code{rMVPA::searchlight}. Otherwise a list containing the prepared
+#'   components and searchlight function.
+#' @export
+mvpa_projected_searchlight <- function(Y,
+                                       event_model,
+                                       hrf_basis_func = NULL,
+                                       theta_params = NULL,
+                                       hrf_basis_matrix = NULL,
+                                       lambda_global = 0,
+                                       lambda_adaptive_method = "none",
+                                       collapse_method = "rss",
+                                       diagnostics = FALSE,
+                                       ...) {
+  X_obj <- make_trialwise_X(event_model,
+                            hrf_basis_func = hrf_basis_func,
+                            theta_params = theta_params,
+                            hrf_basis_matrix = hrf_basis_matrix,
+                            diagnostics = diagnostics)
+  X_theta <- X_obj$X
+  proj_comp <- build_projector(X_theta,
+                               lambda_global = lambda_global,
+                               diagnostics = diagnostics)
+
+  N_trials <- length(event_model$onsets)
+  K_hrf <- ncol(as.matrix(X_obj$hrf_info$basis))
+
+  sl_FUN <- function(Y_sl, sl_info = NULL) {
+    proj_res <- adaptive_ridge_projector(
+      Y_sl,
+      proj_comp,
+      lambda_adaptive_method = lambda_adaptive_method,
+      lambda_floor_global = lambda_global,
+      X_theta_for_EB_residuals = as.matrix(X_theta),
+      diagnostics = diagnostics
+    )
+    coll_res <- collapse_beta(
+      proj_res$Z_sl_raw,
+      N_trials,
+      K_hrf,
+      method = collapse_method,
+      diagnostics = diagnostics
+    )
+    diag_out <- NULL
+    if (diagnostics) {
+      diag_out <- list(lambda_sl = proj_res$diag_data$lambda_sl_chosen,
+                       w_sl = coll_res$w_sl)
+    }
+    list(A_sl = coll_res$A_sl, diag_data = diag_out)
+  }
+
+  if (requireNamespace("rMVPA", quietly = TRUE)) {
+    res <- rMVPA::searchlight(
+      Y,
+      FUN = sl_FUN,
+      .combine = combine_projection_diagnostics,
+      ...
+    )
+    if (diagnostics) {
+      attr(res, "diagnostics") <- list(layer1 = attr(X_obj, "diagnostics"),
+                                        layer2 = attr(proj_comp, "diagnostics"))
+    }
+    return(res)
+  }
+
+  message("rMVPA package not available - returning components for manual use")
+  out <- list(FUN = sl_FUN, design = X_obj, projector = proj_comp)
+  if (diagnostics) {
+    out$diagnostics <- list(layer1 = attr(X_obj, "diagnostics"),
+                            layer2 = attr(proj_comp, "diagnostics"))
+  }
+  out
+}

--- a/tests/testthat/test-mvpa-projected-searchlight.R
+++ b/tests/testthat/test-mvpa-projected-searchlight.R
@@ -1,0 +1,15 @@
+context("mvpa_projected_searchlight")
+
+test_that("mvpa_projected_searchlight returns FUN and components when rMVPA missing", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  Y <- matrix(1, nrow = 6, ncol = 2)
+  res <- mvpa_projected_searchlight(Y, em, hrf_basis_matrix = basis,
+                                    lambda_global = 0.5, diagnostics = TRUE)
+  expect_true(is.function(res$FUN))
+  expect_s3_class(res$projector, "fr_projector")
+  sl_res <- res$FUN(Y)
+  expect_equal(dim(sl_res$A_sl), c(length(em$onsets), ncol(Y)))
+  expect_true(!is.null(sl_res$diag_data))
+})


### PR DESCRIPTION
## Summary
- add `mvpa_projected_searchlight` placeholder integration with rMVPA
- implement `combine_projection_diagnostics` aggregator
- create `explain_projection_results` for lambda maps
- export new functions
- test projected searchlight setup

## Testing
- `R CMD check` *(fails: R is not available)*