### PR TITLE
Add input validation to build_projector

### DIFF
--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -11,6 +11,14 @@
 #'   \code{R} and \code{K_global} if requested.
 #' @export
 build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE) {
+  if (!inherits(X_theta, c("matrix", "Matrix"))) {
+    stop("X_theta must be a matrix or Matrix")
+  }
+  if (!is.numeric(lambda_global) || length(lambda_global) != 1 ||
+      lambda_global < 0) {
+    stop("lambda_global must be a single non-negative numeric value")
+  }
+
   start_time <- proc.time()["elapsed"]
 
   qr_obj <- Matrix::qr(X_theta)

--- a/tests/testthat/test-build-projector.R
+++ b/tests/testthat/test-build-projector.R
@@ -41,3 +41,12 @@ test_that("build_projector warns on high condition number", {
   X <- Matrix::Matrix(matrix(c(1,1,1,1), 2, 2), sparse = TRUE)
   expect_warning(build_projector(X))
 })
+
+test_that("build_projector validates inputs", {
+  expect_error(build_projector(list()), "X_theta must be")
+  X <- matrix(1, nrow = 2, ncol = 2)
+  expect_error(build_projector(X, lambda_global = c(1, 2)),
+               "lambda_global must be")
+  expect_error(build_projector(X, lambda_global = -1),
+               "lambda_global must be")
+})


### PR DESCRIPTION
## Summary
- validate arguments at start of `build_projector`
- test invalid inputs for `build_projector`

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: R not installed)*