### PR TITLE
Validate inputs in fr_design_matrix

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -12,6 +12,17 @@
 #' @return An object of class \code{fr_design_matrix}.
 #' @export
 fr_design_matrix <- function(X, event_model = NULL, hrf_info = list()) {
+  if (!is.matrix(X) && !inherits(X, "dgCMatrix")) {
+    stop("X must be a base matrix or Matrix::dgCMatrix")
+  }
+  if (!is.null(event_model) &&
+      !is.list(event_model) &&
+      !inherits(event_model, "fmrireg_event_model")) {
+    stop("event_model must be a list or fmrireg_event_model")
+  }
+  if (!is.list(hrf_info)) {
+    stop("hrf_info must be a list")
+  }
   structure(
     list(X = X, event_model = event_model, hrf_info = hrf_info),
     class = "fr_design_matrix"

--- a/tests/testthat/test-fr-design-matrix.R
+++ b/tests/testthat/test-fr-design-matrix.R
@@ -1,0 +1,14 @@
+library(testthat)
+
+# Tests for fr_design_matrix input validation
+
+mat <- matrix(0, nrow = 2, ncol = 2)
+
+# X must be matrix or dgCMatrix
+expect_error(fr_design_matrix(1), "X must be a base matrix or Matrix::dgCMatrix")
+
+# event_model must be list or fmrireg_event_model
+expect_error(fr_design_matrix(mat, event_model = 1), "event_model must be a list or fmrireg_event_model")
+
+# hrf_info must be list
+expect_error(fr_design_matrix(mat, hrf_info = 1), "hrf_info must be a list")


### PR DESCRIPTION
## Summary
- add explicit type checking to `fr_design_matrix`
- test error handling for invalid inputs

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `bash: R: command not found`)*