### PR TITLE
Add print methods and snapshot tests

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -10,6 +10,8 @@ export(make_trialwise_X)
 export(build_projector)
 export(adaptive_ridge_projector)
 export(collapse_beta)
+export(print.fr_design_matrix)
+export(print.fr_projector)
 
 export(run_projected_searchlight)
 export(mvpa_projected_searchlight)

--- a/R/methods.R
+++ b/R/methods.R
@@ -1,0 +1,45 @@
+#' Print methods for fmriproj objects
+#'
+#' Simple summaries of `fr_design_matrix` and `fr_projector` objects.
+#'
+#' @param x Object to print.
+#' @param ... Additional arguments ignored.
+#' @return Invisibly returns `x`.
+#' @name print_methods
+NULL
+
+#' @rdname print_methods
+#' @export
+print.fr_design_matrix <- function(x, ...) {
+  dims <- dim(x$X)
+  cat("fr_design_matrix\n")
+  cat(" - X dims:", dims[1], "x", dims[2])
+  if (inherits(x$X, "dgCMatrix")) cat(" [sparse]\n") else cat(" [dense]\n")
+  if (is.null(x$event_model)) {
+    cat(" - event_model: none\n")
+  } else {
+    cat(" - event_model present\n")
+  }
+  invisible(x)
+}
+
+#' @rdname print_methods
+#' @export
+print.fr_projector <- function(x, ...) {
+  cat("fr_projector\n")
+  if (!is.null(x$Qt)) {
+    dQt <- dim(x$Qt)
+    cat(" - Qt dims:", dQt[1], "x", dQt[2], "\n")
+  }
+  if (!is.null(x$R)) {
+    dR <- dim(x$R)
+    cat(" - R dims:", dR[1], "x", dR[2], "\n")
+  }
+  if (is.null(x$K_global)) {
+    cat(" - K_global: none\n")
+  } else {
+    dK <- dim(x$K_global)
+    cat(" - K_global dims:", dK[1], "x", dK[2], "\n")
+  }
+  invisible(x)
+}

--- a/tests/testthat/_snaps/print-methods.md
+++ b/tests/testthat/_snaps/print-methods.md
@@ -1,0 +1,16 @@
+# Snapshot of `print.fr_design_matrix outputs summary`
+
+```
+fr_design_matrix
+ - X dims: 6 x 6 [sparse]
+ - event_model present
+```
+
+# Snapshot of `print.fr_projector outputs summary`
+
+```
+fr_projector
+ - Qt dims: 6 x 6 
+ - R dims: 6 x 6 
+ - K_global dims: 6 x 6 
+```

--- a/tests/testthat/test-print-methods.R
+++ b/tests/testthat/test-print-methods.R
@@ -1,0 +1,18 @@
+context("print methods")
+
+test_that("print.fr_design_matrix outputs summary", {
+  em <- list(onsets = c(0L, 2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  dm <- build_design_matrix(em, hrf_basis_matrix = basis)
+  expect_snapshot_output(print(dm))
+})
+
+test_that("print.fr_projector outputs summary", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  dm <- build_design_matrix(em, hrf_basis_matrix = basis)
+  proj <- build_projector(dm$X)
+  expect_snapshot_output(print(proj))
+})


### PR DESCRIPTION
## Summary
- create `print.fr_design_matrix` and `print.fr_projector` in new `methods.R`
- export the new print methods
- test printing behaviour with snapshots

## Testing
- `R CMD check` *(fails: R not installed)*