### PR TITLE
Validate amplitudes and modulators lengths

### DIFF
--- a/R/trialwise_design.R
+++ b/R/trialwise_design.R
@@ -43,6 +43,13 @@ build_design_matrix <- function(event_model,
   modulators <- event_model$modulator
   if (is.null(modulators)) modulators <- rep(1, length(onsets))
 
+  if (length(amplitudes) != length(onsets)) {
+    stop("'amplitudes' must be the same length as 'onsets'")
+  }
+  if (length(modulators) != length(onsets)) {
+    stop("'modulator' must be the same length as 'onsets'")
+  }
+
   if (is.null(hrf_basis_matrix)) {
     if (is.null(hrf_basis_func)) {
       stop("Provide either hrf_basis_matrix or hrf_basis_func")

--- a/tests/testthat/test-make-trialwise-X.R
+++ b/tests/testthat/test-make-trialwise-X.R
@@ -40,3 +40,17 @@ test_that("long HRF basis is decimated", {
   expect_equal(nrow(res$hrf_info$basis), 4L)
 })
 
+test_that("input lengths are validated", {
+  basis <- matrix(1, nrow = 2, ncol = 1)
+
+  em_amp <- list(onsets = c(0L, 2L), n_time = 6L,
+                 amplitudes = c(1))
+  expect_error(build_design_matrix(em_amp, hrf_basis_matrix = basis),
+               "amplitudes")
+
+  em_mod <- list(onsets = c(0L, 2L), n_time = 6L,
+                 modulator = c(1))
+  expect_error(build_design_matrix(em_mod, hrf_basis_matrix = basis),
+               "modulator")
+})
+


### PR DESCRIPTION
## Summary
- check `amplitudes` and `modulator` lengths in `build_design_matrix`
- test that mismatched lengths throw errors

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*