### PR TITLE
Add validation to sparse matrix helpers

### DIFF
--- a/R/rcpp_helpers.R
+++ b/R/rcpp_helpers.R
@@ -11,6 +11,14 @@
 #' @return A `dgCMatrix` representing the sparse matrix.
 #' @export
 make_spmat_triplet <- function(i, j, x, nrow, ncol) {
+  stopifnot(length(i) == length(j), length(i) == length(x))
+  if (anyNA(i) || anyNA(j) || anyNA(x))
+    stop("Indices and values must not contain NA")
+  if (any(i < 0) || any(j < 0))
+    stop("Indices must be non-negative")
+  if (any(i >= nrow) || any(j >= ncol))
+    stop("Indices out of range")
+
   .triplet_to_spmat_cpp(as.integer(i), as.integer(j), as.numeric(x),
                         as.integer(nrow), as.integer(ncol))
 }
@@ -24,5 +32,12 @@ make_spmat_triplet <- function(i, j, x, nrow, ncol) {
 #' @return Dense product matrix `A %*% B`.
 #' @export
 spmat_dense_prod <- function(A, B) {
+  if (!inherits(A, "dgCMatrix"))
+    stop("A must be a 'dgCMatrix'")
+  if (!is.matrix(B))
+    stop("B must be a matrix")
+  if (ncol(A) != nrow(B))
+    stop("Non-conformable matrices: ncol(A) != nrow(B)")
+
   .spmat_dense_prod_cpp(A, B)
 }

--- a/tests/testthat/test-rcpp-helpers.R
+++ b/tests/testthat/test-rcpp-helpers.R
@@ -16,3 +16,20 @@ test_that("spmat_dense_prod multiplies correctly", {
   res <- spmat_dense_prod(sm, dense)
   expect_equal(res, as.matrix(sm %*% dense))
 })
+
+test_that("make_spmat_triplet validates inputs", {
+  expect_error(make_spmat_triplet(0L, c(0L, 1L), 1, 2L, 2L))
+  expect_error(make_spmat_triplet(c(0L, NA), c(0L, 1L), c(1, 2), 2L, 2L),
+               "must not contain NA")
+  expect_error(make_spmat_triplet(c(-1L, 0L), c(0L, 1L), c(1, 2), 2L, 2L),
+               "non-negative")
+  expect_error(make_spmat_triplet(c(0L, 1L), c(0L, 2L), c(1, 2), 2L, 2L),
+               "out of range")
+})
+
+test_that("spmat_dense_prod validates inputs", {
+  sm <- make_spmat_triplet(0L, 0L, 1, 2L, 2L)
+  expect_error(spmat_dense_prod(as.matrix(sm), matrix(1, 2, 2)), "dgCMatrix")
+  expect_error(spmat_dense_prod(sm, 1), "matrix")
+  expect_error(spmat_dense_prod(sm, matrix(1, 3, 2)), "Non-conformable")
+})


### PR DESCRIPTION
## Summary
- enforce sanity checks in `make_spmat_triplet`
- validate inputs for `spmat_dense_prod`
- expand tests for new error conditions

## Testing
- `Rscript -e 'print("Running tests")'` *(fails: command not found)*