### PR TITLE
Fix diagnostics length handling

### DIFF
--- a/R/combine_projection_diagnostics.R
+++ b/R/combine_projection_diagnostics.R
@@ -11,13 +11,12 @@
 #'   a list of per-searchlight diagnostic entries.
 #' @export
 combine_projection_diagnostics <- function(x, y) {
+  diag_val <- cap_diagnostics(list(y$diag_data))
   if (is.null(x)) {
-    dl <- list(y$diag_data)
     return(list(results = list(y),
-                diagnostics = cap_diagnostics(dl)))
+                diagnostics = list(diag_val)))
   }
-  x$results <- c(x$results, list(y))
-  new_diag <- cap_diagnostics(list(y$diag_data))
-  x$diagnostics <- c(x$diagnostics, new_diag)
+  x$results[[length(x$results) + 1L]] <- y
+  x$diagnostics[[length(x$diagnostics) + 1L]] <- diag_val
   x
 }

--- a/tests/testthat/test-combine-projection-diagnostics.R
+++ b/tests/testthat/test-combine-projection-diagnostics.R
@@ -1,0 +1,21 @@
+context("combine_projection_diagnostics")
+
+test_that("diagnostics retained per result", {
+  y1 <- list(A_sl = matrix(1), diag_data = list(lambda_sl = 0.1))
+  out <- combine_projection_diagnostics(NULL, y1)
+  y2 <- list(A_sl = matrix(2), diag_data = list(lambda_sl = 0.2))
+  out <- combine_projection_diagnostics(out, y2)
+  expect_equal(length(out$results), 2L)
+  expect_equal(length(out$diagnostics), 2L)
+  expect_equal(out$diagnostics[[1]]$lambda_sl, 0.1)
+  expect_equal(out$diagnostics[[2]]$lambda_sl, 0.2)
+})
+
+test_that("NULL diagnostics preserve length", {
+  old <- options(fmriproj.diagnostics_memory_limit = 0)
+  on.exit(options(old), add = TRUE)
+  y1 <- list(A_sl = matrix(1), diag_data = list(lambda_sl = 0.1))
+  res <- combine_projection_diagnostics(NULL, y1)
+  expect_equal(length(res$diagnostics), 1L)
+  expect_null(res$diagnostics[[1]])
+})


### PR DESCRIPTION
## Summary
- fix `combine_projection_diagnostics()` to keep diagnostics one-per-result
- add regression tests for diagnostic aggregation

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `bash: R: command not found`)*