### PR TITLE
Support sparse X in HRF optimization

### DIFF
--- a/R/adaptive_ridge_projector.R
+++ b/R/adaptive_ridge_projector.R
@@ -12,7 +12,8 @@
 #' @param lambda_floor_global Minimum ridge penalty to apply.
 #' @param X_theta_for_EB_residuals Optional design matrix `X(θ)` used for
 #'   computing residuals when `lambda_adaptive_method = "EB"` or when
-#'   cross-validating local lambda.
+#'   cross-validating local lambda. Can be a dense matrix or a sparse
+#'   `Matrix::dgCMatrix`.
 #' @param diagnostics Logical; return diagnostic information.
 #' @return A list with elements:
 #'   \item{Z_sl_raw}{Projected coefficients ((N*K) x V_sl).}

--- a/R/optimize_joint_hrf_mvpa.R
+++ b/R/optimize_joint_hrf_mvpa.R
@@ -53,7 +53,7 @@ optimize_hrf_mvpa <- function(theta_init,
       proj_comp,
       lambda_adaptive_method = lambda_adaptive_method,
       lambda_floor_global = lambda_global,
-      X_theta_for_EB_residuals = as.matrix(X_theta),
+      X_theta_for_EB_residuals = X_theta,
       diagnostics = FALSE
     )
     N_trials <- length(event_model$onsets)


### PR DESCRIPTION
## Summary
- allow `optimize_hrf_mvpa()` to pass sparse design matrices directly
- document sparse input support for `adaptive_ridge_projector`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`