### PR TITLE
Optimize design conversion in searchlight

### DIFF
--- a/R/mvpa_projected_searchlight.R
+++ b/R/mvpa_projected_searchlight.R
@@ -39,6 +39,10 @@ run_projected_searchlight <- function(Y,
                                hrf_basis_matrix = hrf_basis_matrix,
                                diagnostics = diagnostics)
   X_theta <- X_obj$X
+  X_theta_dense <- NULL
+  if (lambda_adaptive_method %in% c("EB", "LOOcv_local")) {
+    X_theta_dense <- as.matrix(X_theta)
+  }
   proj_comp <- build_projector(X_theta,
                                lambda_global = lambda_global,
                                diagnostics = diagnostics)
@@ -52,7 +56,7 @@ run_projected_searchlight <- function(Y,
       proj_comp,
       lambda_adaptive_method = lambda_adaptive_method,
       lambda_floor_global = lambda_global,
-      X_theta_for_EB_residuals = as.matrix(X_theta),
+      X_theta_for_EB_residuals = X_theta_dense,
       diagnostics = diagnostics
     )
     coll_res <- collapse_beta(

--- a/tests/testthat/test-mvpa-projected-searchlight.R
+++ b/tests/testthat/test-mvpa-projected-searchlight.R
@@ -13,3 +13,15 @@ test_that("run_projected_searchlight returns FUN and components when rMVPA missi
   expect_equal(dim(sl_res$A_sl), c(length(em$onsets), ncol(Y)))
   expect_true(!is.null(sl_res$diag_data))
 })
+
+test_that("run_projected_searchlight computes dense matrix for EB", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  Y <- matrix(rnorm(12), nrow = 6, ncol = 2)
+  res <- run_projected_searchlight(Y, em, hrf_basis_matrix = basis,
+                                    lambda_global = 0.5,
+                                    lambda_adaptive_method = "EB")
+  sl_res <- res$FUN(Y)
+  expect_equal(dim(sl_res$A_sl), c(length(em$onsets), ncol(Y)))
+})


### PR DESCRIPTION
## Summary
- only convert `X_theta` to dense when needed for EB/LOO CV
- pass `NULL` when no conversion is required
- test projected searchlight with and without dense conversion

## Testing
- `which R` *(fails: command not found)*