### PR TITLE
Add Y row validation

### DIFF
--- a/R/mvpa_projected_searchlight.R
+++ b/R/mvpa_projected_searchlight.R
@@ -33,6 +33,9 @@ run_projected_searchlight <- function(Y,
                                       collapse_method = "rss",
                                       diagnostics = FALSE,
                                       ...) {
+  if (nrow(Y) != event_model$n_time) {
+    stop("nrow(Y) must match event_model$n_time")
+  }
   X_obj <- build_design_matrix(event_model,
                                hrf_basis_func = hrf_basis_func,
                                theta_params = theta_params,

--- a/tests/testthat/test-mvpa-projected-searchlight.R
+++ b/tests/testthat/test-mvpa-projected-searchlight.R
@@ -13,3 +13,11 @@ test_that("run_projected_searchlight returns FUN and components when rMVPA missi
   expect_equal(dim(sl_res$A_sl), c(length(em$onsets), ncol(Y)))
   expect_true(!is.null(sl_res$diag_data))
 })
+
+test_that("run_projected_searchlight errors when Y rows mismatch", {
+  em <- list(onsets = c(0L), n_time = 6L)
+  basis <- matrix(1, nrow = 1, ncol = 1)
+  Y <- matrix(1, nrow = 5, ncol = 2)
+  expect_error(run_projected_searchlight(Y, em, hrf_basis_matrix = basis),
+               "nrow(Y) must match event_model\$n_time")
+})


### PR DESCRIPTION
## Summary
- validate that `nrow(Y)` matches `event_model$n_time` in `run_projected_searchlight`
- test mismatch handling

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*