### PR TITLE
Handle missing diagnostic data in searchlight

### DIFF
--- a/R/mvpa_projected_searchlight.R
+++ b/R/mvpa_projected_searchlight.R
@@ -64,8 +64,17 @@ run_projected_searchlight <- function(Y,
     )
     diag_out <- NULL
     if (diagnostics) {
-      dl <- list(lambda_sl = proj_res$diag_data$lambda_sl_chosen,
-                 w_sl = coll_res$w_sl)
+      dl <- list()
+      lambda_val <- NA
+      if (!is.null(proj_res$diag_data)) {
+        if (!is.null(proj_res$diag_data$lambda_sl_chosen)) {
+          lambda_val <- proj_res$diag_data$lambda_sl_chosen
+        }
+      }
+      dl$lambda_sl <- lambda_val
+      if (!is.null(coll_res$w_sl)) {
+        dl$w_sl <- coll_res$w_sl
+      }
       diag_out <- cap_diagnostics(dl)
     }
     list(A_sl = coll_res$A_sl, diag_data = diag_out)

--- a/tests/testthat/test-mvpa-projected-searchlight.R
+++ b/tests/testthat/test-mvpa-projected-searchlight.R
@@ -13,3 +13,19 @@ test_that("run_projected_searchlight returns FUN and components when rMVPA missi
   expect_equal(dim(sl_res$A_sl), c(length(em$onsets), ncol(Y)))
   expect_true(!is.null(sl_res$diag_data))
 })
+
+test_that("run_projected_searchlight handles trimmed diagnostics", {
+  old <- options(fmriproj.diagnostics_memory_limit = 1)
+  on.exit(options(old), add = TRUE)
+
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  Y <- matrix(1, nrow = 6, ncol = 2)
+
+  res <- run_projected_searchlight(Y, em, hrf_basis_matrix = basis,
+                                    lambda_global = 0.5, diagnostics = TRUE)
+  sl_res <- res$FUN(Y)
+  expect_equal(dim(sl_res$A_sl), c(length(em$onsets), ncol(Y)))
+  expect_null(sl_res$diag_data)
+})


### PR DESCRIPTION
## Summary
- guard against NULL diagnostic elements in `run_projected_searchlight`
- return NA or omit fields when diagnostics are absent
- test that trimmed diagnostics don't crash the searchlight

## Testing
- `Rscript --version` *(fails: command not found)*