### PR TITLE
Fix inconsistent return type in fit_pp

### DIFF
--- a/R/progressive_projection.R
+++ b/R/progressive_projection.R
@@ -42,7 +42,7 @@ fit_pp <- function(A_sl_train, labels_train, method = "LDA", dims = 2) {
     } else {
       eig <- eigen(mat)
       idx <- order(Re(eig$values), decreasing = TRUE)
-      W <- Re(eig$vectors[, idx[seq_len(min(dims, ncol(eig$vectors)))]])
+      W <- Re(eig$vectors[, idx[seq_len(min(dims, ncol(eig$vectors)))], drop = FALSE])
     }
   } else { # PLS-DA
     Y_ind <- model.matrix(~ labels_train - 1)


### PR DESCRIPTION
## Summary
- keep the projection matrix from `fit_pp` a matrix when only one dimension is returned

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*