### PR TITLE
Implement central difference derivative

### DIFF
--- a/R/hrf_basis_spmg3_theta.R
+++ b/R/hrf_basis_spmg3_theta.R
@@ -9,6 +9,10 @@
 #'
 #' @return Matrix with length(t) rows and 3 columns: canonical HRF,
 #'   temporal derivative, and dispersion derivative.
+#'
+#' Derivatives are estimated using a central difference scheme that
+#' accommodates irregularly spaced `t`. Forward and backward
+#' differences are applied at the boundaries.
 #' @export
 hrf_basis_spmg3_theta <- function(theta = c(1, 1), t) {
   delay_scale <- theta[1]
@@ -23,9 +27,25 @@ hrf_basis_spmg3_theta <- function(theta = c(1, 1), t) {
     0.35 * stats::dgamma(t, shape = p2, rate = d2)
   if (max(hrf) != 0) hrf <- hrf / max(hrf)
 
-  dt <- if (length(t) > 1) mean(diff(t)) else 1
-  deriv1 <- c(diff(hrf) / dt, 0)
-  deriv2 <- c(diff(deriv1) / dt, 0)
+  n <- length(hrf)
+  deriv1 <- numeric(n)
+  deriv2 <- numeric(n)
+
+  if (n > 1) {
+    deriv1[1] <- (hrf[2] - hrf[1]) / (t[2] - t[1])
+    deriv1[n] <- (hrf[n] - hrf[n - 1]) / (t[n] - t[n - 1])
+    if (n > 2) {
+      deriv1[2:(n - 1)] <- (hrf[3:n] - hrf[1:(n - 2)]) /
+        (t[3:n] - t[1:(n - 2)])
+    }
+
+    deriv2[1] <- (deriv1[2] - deriv1[1]) / (t[2] - t[1])
+    deriv2[n] <- (deriv1[n] - deriv1[n - 1]) / (t[n] - t[n - 1])
+    if (n > 2) {
+      deriv2[2:(n - 1)] <- (deriv1[3:n] - deriv1[1:(n - 2)]) /
+        (t[3:n] - t[1:(n - 2)])
+    }
+  }
 
   cbind(hrf, deriv1, deriv2)
 }


### PR DESCRIPTION
## Summary
- compute derivatives in `hrf_basis_spmg3_theta()` using a central difference approach
- document the boundary handling for derivative calculation

## Testing
- `R CMD build .` *(fails: `bash: R: command not found`)*