### PR TITLE
Add HRF basis dimension check

### DIFF
--- a/R/explain_projection_results.R
+++ b/R/explain_projection_results.R
@@ -37,6 +37,10 @@ explain_projection_results <- function(sl_results, mask_dims, hrf_basis_matrix =
     }
     if (!is.null(hrf_basis_matrix)) {
       w_mean <- rowMeans(w_mat)
+      if (ncol(hrf_basis_matrix) != length(w_mean)) {
+        stop("Number of columns in hrf_basis_matrix (", ncol(hrf_basis_matrix),
+             ") must match length of collapse weights (", length(w_mean), ")")
+      }
       effective_hrf <- as.numeric(hrf_basis_matrix %*% w_mean)
     }
   }

--- a/tests/testthat/test-explain.R
+++ b/tests/testthat/test-explain.R
@@ -12,3 +12,15 @@ test_that("explain_projection_results returns maps", {
   expect_equal(length(res$w_maps[[1]]), 2)
   expect_equal(length(res$effective_hrf), nrow(basis))
 })
+
+test_that("explain_projection_results errors for basis/w_mean mismatch", {
+  sl_res <- list(diagnostics = list(
+    list(lambda_sl = 0.5, w_sl = c(1,0)),
+    list(lambda_sl = 0.6, w_sl = c(0,1))
+  ))
+  bad_basis <- matrix(seq_len(9), nrow = 3)  # 3 columns, w_mean length is 2
+  expect_error(
+    explain_projection_results(sl_res, mask_dims = c(2), hrf_basis_matrix = bad_basis),
+    "Number of columns in hrf_basis_matrix"
+  )
+})


### PR DESCRIPTION
## Summary
- ensure `explain_projection_results` validates the HRF basis size before
  computing effective HRF
- expand tests for the new dimension check

## Testing
- `Rscript -e "1+1"` *(fails: command not found)*