### PR TITLE
Handle w_sl omission in diagnostic maps

### DIFF
--- a/tests/testthat/test-explain.R
+++ b/tests/testthat/test-explain.R
@@ -12,3 +12,14 @@ test_that("explain_projection_results returns maps", {
   expect_equal(length(res$w_maps[[1]]), 2)
   expect_equal(length(res$effective_hrf), nrow(basis))
 })
+
+test_that("explain_projection_results inserts NA for missing w_sl", {
+  sl_res <- list(diagnostics = list(
+    list(lambda_sl = 0.5, w_sl = c(1,0)),
+    list(lambda_sl = 0.6, w_sl = NULL),
+    list(lambda_sl = 0.7, w_sl = c(0,1))
+  ))
+  res <- explain_projection_results(sl_res, mask_dims = c(3))
+  expect_equal(length(res$w_maps[[1]]), 3)
+  expect_true(is.na(res$w_maps[[1]][2]))
+})


### PR DESCRIPTION
## Summary
- produce w_maps when `w_sl` is partially available
- fill missing searchlights with `NA`
- clarify behavior in `explain_projection_results` docs
- add unit test for missing `w_sl`

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*