### PR TITLE
Fix K_global computation for lambda 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     tibble,
     Rcpp,
     RcppArmadillo,
+    MASS,
     assertthat,
     purrr,
     glmnet,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,6 @@
 useDynLib(fmriproj, .registration=TRUE)
 importFrom(Rcpp, evalCpp)
+importFrom(MASS, ginv)
 export(fr_design_matrix)
 export(fr_projector)
 export(make_spmat_triplet)

--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -8,7 +8,9 @@
 #' @param diagnostics Logical; attach timing and condition number.
 #'
 #' @return An object of class \code{fr_projector} containing \code{Qt},
-#'   \code{R} and \code{K_global} if requested.
+#'   \code{R} and \code{K_global}. When \code{lambda_global} is zero
+#'   \code{K_global} is the (pseudo-)inverse of \code{R} times
+#'   \code{Qt}; otherwise ridge regularization is applied.
 #' @export
 build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE) {
   start_time <- proc.time()["elapsed"]
@@ -26,7 +28,10 @@ build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE) {
     m <- ncol(R)
     K_global <- solve(crossprod(R) + diag(lambda_global, m), t(R) %*% Qt)
   } else {
-    K_global <- Qt
+    K_global <- tryCatch(
+      solve(R, Qt),
+      error = function(e) MASS::ginv(R) %*% Qt
+    )
   }
 
   build_time <- proc.time()["elapsed"] - start_time

--- a/tests/testthat/test-build-projector.R
+++ b/tests/testthat/test-build-projector.R
@@ -11,6 +11,8 @@ test_that("build_projector sparse QR works", {
   R_exp <- qr.R(qr_obj)
   expect_equal(proj$Qt, Qt_exp)
   expect_equal(proj$R, R_exp)
+  K_exp <- solve(R_exp, Qt_exp)
+  expect_equal(proj$K_global, K_exp)
 })
 
 test_that("build_projector applies ridge", {
@@ -40,4 +42,14 @@ test_that("build_projector diagnostics", {
 test_that("build_projector warns on high condition number", {
   X <- Matrix::Matrix(matrix(c(1,1,1,1), 2, 2), sparse = TRUE)
   expect_warning(build_projector(X))
+})
+
+test_that("build_projector uses ginv when R is singular", {
+  X <- Matrix::Matrix(matrix(c(1,1,1,1), 2, 2), sparse = TRUE)
+  proj <- suppressWarnings(build_projector(X))
+  qr_obj <- qr(as.matrix(X))
+  Qt_exp <- t(qr.Q(qr_obj))
+  R_exp <- qr.R(qr_obj)
+  K_exp <- MASS::ginv(R_exp) %*% Qt_exp
+  expect_equal(proj$K_global, K_exp)
 })


### PR DESCRIPTION
## Summary
- compute unregularized projector using `solve(R, Qt)`
- fall back to `MASS::ginv` if `R` is singular
- document the new `K_global` semantics
- update NAMESPACE and DESCRIPTION for MASS dependency
- adjust unit tests for new behavior

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*