### PR TITLE
Fix gradient arg name and warnings

### DIFF
--- a/R/optimize_joint_hrf_mvpa.R
+++ b/R/optimize_joint_hrf_mvpa.R
@@ -18,6 +18,7 @@
 #' @param diagnostics Logical; return optimization trace.
 #' @param use_fd_grad Logical; compute gradient using finite differences if
 #'   `TMB` is installed and `hrf_basis_func` is marked as TMB compatible.
+#' @param use_tmb Deprecated alias for `use_fd_grad`.
 #' @param ... Additional arguments passed to `inner_cv_fn`.
 #'
 #' @return A list with elements `theta_hat`, `optim_details`, and optional
@@ -36,9 +37,15 @@ optimize_hrf_mvpa <- function(theta_init,
                               classifier_for_w_optim = NULL,
                               optim_w_params = list(),
                               use_fd_grad = FALSE,
+                              use_tmb = NULL,
                               diagnostics = FALSE,
                               ...) {
   trace_env <- new.env(parent = emptyenv())
+
+  if (!is.null(use_tmb)) {
+    warning("`use_tmb` is deprecated; use `use_fd_grad` instead.", call. = FALSE)
+    use_fd_grad <- use_tmb
+  }
 
   trace_env$df <- data.frame()
   N_trials <- length(event_model$onsets)

--- a/tests/testthat/test-optimize-joint-hrf.R
+++ b/tests/testthat/test-optimize-joint-hrf.R
@@ -22,7 +22,7 @@ test_that("optimize_hrf_mvpa basic flow", {
   expect_true(nrow(res$diagnostics$theta_trace) >= 1)
 })
 
-test_that("warning when use_tmb but basis not compatible", {
+test_that("warning when use_fd_grad but basis not compatible", {
   Y <- matrix(1, nrow = 2, ncol = 1)
   em <- list(onsets = c(0L), n_time = 2L, basis_length = 1L)
   basis_fun <- function(theta, t) {
@@ -34,7 +34,7 @@ test_that("warning when use_tmb but basis not compatible", {
                        event_model = em,
                        inner_cv_fn = sum,
                        hrf_basis_func = basis_fun,
-                       use_tmb = TRUE,
+                       use_fd_grad = TRUE,
                        optim_method = "Nelder-Mead"),
     "gradients set to NULL"
   )
@@ -54,7 +54,7 @@ test_that("warning when TMB unavailable", {
                        event_model = em,
                        inner_cv_fn = sum,
                        hrf_basis_func = basis_fun,
-                       use_tmb = TRUE,
+                       use_fd_grad = TRUE,
                        optim_method = "Nelder-Mead"),
     "gradients set to NULL"
   )


### PR DESCRIPTION
## Summary
- add deprecation warning for `use_tmb`
- update tests to call `use_fd_grad`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*