### PR TITLE
Clarify gradient handling

### DIFF
--- a/R/optimize_joint_hrf_mvpa.R
+++ b/R/optimize_joint_hrf_mvpa.R
@@ -16,8 +16,9 @@
 #' @param collapse_method Collapse method for `collapse_beta`.
 #' @param optim_method Optimization method for `stats::optim`.
 #' @param diagnostics Logical; return optimization trace.
-#' @param use_fd_grad Logical; compute gradient using finite differences if
-#'   `TMB` is installed and `hrf_basis_func` is marked as TMB compatible.
+#' @param use_fd_grad Logical; compute gradient using finite differences.
+#'   An optional TMB-based implementation can be added, but there is no
+#'   requirement for TMB.
 #' @param ... Additional arguments passed to `inner_cv_fn`.
 #'
 #' @return A list with elements `theta_hat`, `optim_details`, and optional
@@ -89,18 +90,13 @@ optimize_hrf_mvpa <- function(theta_init,
 
   grad_fn <- NULL
   if (use_fd_grad) {
-    if (requireNamespace("TMB", quietly = TRUE) &&
-        isTRUE(attr(hrf_basis_func, "tmb_compatible"))) {
-      grad_fn <- function(th) {
-        eps <- 1e-6
-        sapply(seq_along(th), function(i) {
-          th_eps <- th
-          th_eps[i] <- th_eps[i] + eps
-          (loss_fn_theta(th_eps) - loss_fn_theta(th)) / eps
-        })
-      }
-    } else {
-      warning("use_fd_grad is TRUE but TMB or hrf_basis_func compatibility is missing")
+    grad_fn <- function(th) {
+      eps <- 1e-6
+      sapply(seq_along(th), function(i) {
+        th_eps <- th
+        th_eps[i] <- th_eps[i] + eps
+        (loss_fn_theta(th_eps) - loss_fn_theta(th)) / eps
+      })
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ remotes::install_github("bbuchsbaum/fmriproj")
 - `run_projected_searchlight()`: Runs projected MVPA searchlight analysis
 - `optimize_hrf_mvpa()`: Optimizes HRF parameters for MVPA performance
 
+### Gradient computation
+
+`optimize_hrf_mvpa()` uses finite-difference gradients by default. A future
+release may optionally integrate [TMB](https://github.com/kaskr/adcomp) for
+analytic gradients, but there is currently **no TMB requirement**.
+
 ## License
 
 GPL-3 

--- a/tests/testthat/test-optimize-joint-hrf.R
+++ b/tests/testthat/test-optimize-joint-hrf.R
@@ -22,40 +22,18 @@ test_that("optimize_hrf_mvpa basic flow", {
   expect_true(nrow(res$diagnostics$theta_trace) >= 1)
 })
 
-test_that("warning when use_tmb but basis not compatible", {
+test_that("finite-difference gradient runs", {
   Y <- matrix(1, nrow = 2, ncol = 1)
   em <- list(onsets = c(0L), n_time = 2L, basis_length = 1L)
   basis_fun <- function(theta, t) {
     matrix(theta[1], nrow = length(t), ncol = 1)
   }
-  expect_warning(
-    optimize_hrf_mvpa(theta_init = c(1),
-                       Y = Y,
-                       event_model = em,
-                       inner_cv_fn = sum,
-                       hrf_basis_func = basis_fun,
-                       use_tmb = TRUE,
-                       optim_method = "Nelder-Mead"),
-    "gradients set to NULL"
-  )
-})
-
-test_that("warning when TMB unavailable", {
-  skip_if(requireNamespace("TMB", quietly = TRUE))
-  Y <- matrix(1, nrow = 2, ncol = 1)
-  em <- list(onsets = c(0L), n_time = 2L, basis_length = 1L)
-  basis_fun <- function(theta, t) {
-    matrix(theta[1], nrow = length(t), ncol = 1)
-  }
-  attr(basis_fun, "tmb_compatible") <- TRUE
-  expect_warning(
-    optimize_hrf_mvpa(theta_init = c(1),
-                       Y = Y,
-                       event_model = em,
-                       inner_cv_fn = sum,
-                       hrf_basis_func = basis_fun,
-                       use_tmb = TRUE,
-                       optim_method = "Nelder-Mead"),
-    "gradients set to NULL"
-  )
+  res <- optimize_hrf_mvpa(theta_init = c(1),
+                           Y = Y,
+                           event_model = em,
+                           inner_cv_fn = sum,
+                           hrf_basis_func = basis_fun,
+                           use_fd_grad = TRUE,
+                           optim_method = "Nelder-Mead")
+  expect_true(is.numeric(res$theta_hat))
 })


### PR DESCRIPTION
## Summary
- document that optimize_hrf_mvpa uses finite-difference gradients by default
- clarify use_fd_grad parameter and remove TMB requirement
- simplify gradient code to always use finite differences
- update tests for new API

## Testing
- `git status --short`