### PR TITLE
Enhance projector with precomputed matrices

### DIFF
--- a/R/adaptive_ridge_projector.R
+++ b/R/adaptive_ridge_projector.R
@@ -35,6 +35,8 @@ adaptive_ridge_projector <- function(Y_sl,
                                      diagnostics = FALSE) {
   Qt <- projector_components$Qt
   R <- projector_components$R
+  RtR <- projector_components$RtR
+  tRQt <- projector_components$tRQt
 
   if (!is.numeric(lambda_floor_global) || length(lambda_floor_global) != 1 ||
       is.na(lambda_floor_global) || lambda_floor_global < 0) {
@@ -123,8 +125,9 @@ adaptive_ridge_projector <- function(Y_sl,
   }
 
   m <- ncol(R)
-  RtR <- crossprod(R)
-  K_sl <- tryCatch(solve(RtR + diag(lambda_eff, m), t(R) %*% Qt),
+  if (is.null(RtR)) RtR <- crossprod(R)
+  if (is.null(tRQt)) tRQt <- t(R) %*% Qt
+  K_sl <- tryCatch(solve(RtR + diag(lambda_eff, m), tRQt),
                    error = function(e) {
                      stop("Ridge solve failed with lambda ", lambda_eff, ": ", e$message)
                    })

--- a/R/classes.R
+++ b/R/classes.R
@@ -37,10 +37,12 @@ fr_design_matrix <- function(X, event_model = NULL, hrf_info = list()) {
 #' @param Qt Transposed Q matrix from a thin QR decomposition.
 #' @param R  Upper triangular R matrix from QR.
 #' @param K_global Optional global projector matrix.
+#' @param RtR Optional precomputed \eqn{R^\top R} matrix.
+#' @param tRQt Optional precomputed \eqn{R^\top Q^\top} matrix.
 #'
 #' @return An object of class \code{fr_projector}.
 #' @export
-fr_projector <- function(Qt, R, K_global = NULL) {
+fr_projector <- function(Qt, R, K_global = NULL, RtR = NULL, tRQt = NULL) {
   if (!is.matrix(Qt)) {
     stop("Qt must be a matrix")
   }
@@ -58,8 +60,24 @@ fr_projector <- function(Qt, R, K_global = NULL) {
       stop("K_global must have same dimensions as Qt")
     }
   }
+  if (!is.null(RtR)) {
+    if (!is.matrix(RtR)) {
+      stop("RtR must be a matrix")
+    }
+    if (!all(dim(RtR) == c(ncol(R), ncol(R)))) {
+      stop("RtR must be square with dimension equal to ncol(R)")
+    }
+  }
+  if (!is.null(tRQt)) {
+    if (!is.matrix(tRQt)) {
+      stop("tRQt must be a matrix")
+    }
+    if (!all(dim(tRQt) == dim(Qt))) {
+      stop("tRQt must have same dimensions as Qt")
+    }
+  }
   structure(
-    list(Qt = Qt, R = R, K_global = K_global),
+    list(Qt = Qt, R = R, K_global = K_global, RtR = RtR, tRQt = tRQt),
     class = "fr_projector"
   )
 }

--- a/tests/testthat/test-adaptive-collapse.R
+++ b/tests/testthat/test-adaptive-collapse.R
@@ -64,6 +64,21 @@ test_that("adaptive_ridge_projector LOOcv_local works", {
   expect_true(is.finite(res$diag_data$lambda_sl_chosen))
 })
 
+test_that("adaptive_ridge_projector works without precomputed matrices", {
+  em <- list(onsets = c(0L,2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  X <- build_design_matrix(em, hrf_basis_matrix = basis)$X
+  proj_full <- build_projector(X)
+  proj_legacy <- fr_projector(proj_full$Qt, proj_full$R, proj_full$K_global)
+  Y_sl <- matrix(1, nrow = 6, ncol = 1)
+  res1 <- adaptive_ridge_projector(Y_sl, proj_full,
+                                   lambda_floor_global = 0.5)
+  res2 <- adaptive_ridge_projector(Y_sl, proj_legacy,
+                                   lambda_floor_global = 0.5)
+  expect_equal(res1$Z_sl_raw, res2$Z_sl_raw)
+})
+
 test_that("collapse_beta pc works", {
   N_trials <- 2
   K <- 2

--- a/tests/testthat/test-build-projector.R
+++ b/tests/testthat/test-build-projector.R
@@ -13,6 +13,8 @@ test_that("build_projector sparse QR works", {
   expect_equal(proj$R, R_exp)
   K_exp <- solve(R_exp, Qt_exp)
   expect_equal(proj$K_global, K_exp)
+  expect_equal(as.matrix(proj$RtR), crossprod(R_exp))
+  expect_equal(as.matrix(proj$tRQt), t(R_exp) %*% Qt_exp)
 })
 
 test_that("build_projector applies ridge", {

--- a/tests/testthat/test-fr_projector.R
+++ b/tests/testthat/test-fr_projector.R
@@ -22,3 +22,13 @@ test_that("fr_projector validates K_global dimensions", {
   proj <- fr_projector(Qt, R, Kg_good)
   expect_s3_class(proj, "fr_projector")
 })
+
+test_that("fr_projector accepts optional RtR and tRQt", {
+  Qt <- matrix(0, nrow = 2, ncol = 3)
+  R <- matrix(0, nrow = 2, ncol = 2)
+  RtR <- crossprod(R)
+  tRQt <- t(R) %*% Qt
+  proj <- fr_projector(Qt, R, RtR = RtR, tRQt = tRQt)
+  expect_equal(proj$RtR, RtR)
+  expect_equal(proj$tRQt, tRQt)
+})


### PR DESCRIPTION
## Summary
- compute `RtR` and `tRQt` once in `build_projector()`
- keep these matrices in the `fr_projector` object
- allow `adaptive_ridge_projector()` to read precomputed matrices
- extend tests for new fields and backward compatibility

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: `R` not found)*