### PR TITLE
Update EB variance diagnostics

### DIFF
--- a/R/adaptive_ridge_projector.R
+++ b/R/adaptive_ridge_projector.R
@@ -59,8 +59,8 @@ adaptive_ridge_projector <- function(Y_sl,
   }
 
   lambda_sl_raw <- NA
-  s_n_sq <- NA
-  s_b_sq <- NA
+  s_n_sq_vec <- NA
+  s_b_sq_vec <- NA
 
   if (lambda_adaptive_method == "none") {
     lambda_eff <- lambda_floor_global
@@ -71,11 +71,10 @@ adaptive_ridge_projector <- function(Y_sl,
     beta_ols <- solve(R, Qt %*% Y_sl)
     resid_mat <- Y_sl - X_theta_for_EB_residuals %*% beta_ols
     T_obs <- nrow(Y_sl)
-    V_sl <- ncol(Y_sl)
     m <- ncol(R)
-    s_n_sq <- sum(resid_mat^2) / ((T_obs - m) * V_sl)
-    s_b_sq <- sum(beta_ols^2) / (m * V_sl)
-    lambda_sl_raw <- s_n_sq / s_b_sq
+    s_n_sq_vec <- colSums(resid_mat^2) / (T_obs - m)
+    s_b_sq_vec <- colSums(beta_ols^2) / m
+    lambda_sl_raw <- median(s_n_sq_vec / s_b_sq_vec, na.rm = TRUE)
     lambda_eff <- max(lambda_floor_global, lambda_sl_raw)
   } else if (lambda_adaptive_method == "LOOcv_local") {
     if (is.null(X_theta_for_EB_residuals)) {
@@ -135,8 +134,8 @@ adaptive_ridge_projector <- function(Y_sl,
   if (diagnostics) {
     dl <- list(lambda_sl_chosen = lambda_eff,
                lambda_sl_raw = lambda_sl_raw,
-               s_n_sq = s_n_sq,
-               s_b_sq = s_b_sq)
+               s_n_sq_vec = s_n_sq_vec,
+               s_b_sq_vec = s_b_sq_vec)
     diag_list <- cap_diagnostics(dl)
   }
 

--- a/tests/testthat/test-adaptive-collapse.R
+++ b/tests/testthat/test-adaptive-collapse.R
@@ -43,8 +43,12 @@ test_that("adaptive_ridge_projector EB works", {
   diag <- res$diag_data
   expect_true(!is.null(diag))
   expect_true(is.finite(diag$lambda_sl_chosen))
-  expect_true(is.finite(diag$s_n_sq))
-  expect_true(is.finite(diag$s_b_sq))
+  expect_true(is.numeric(diag$s_n_sq_vec))
+  expect_length(diag$s_n_sq_vec, ncol(Y_sl))
+  expect_true(all(is.finite(diag$s_n_sq_vec)))
+  expect_true(is.numeric(diag$s_b_sq_vec))
+  expect_length(diag$s_b_sq_vec, ncol(Y_sl))
+  expect_true(all(is.finite(diag$s_b_sq_vec)))
 })
 
 test_that("adaptive_ridge_projector LOOcv_local works", {


### PR DESCRIPTION
## Summary
- adjust EB variance estimates to keep per-voxel values
- expose per-voxel variance vectors in diagnostics
- update EB tests for new diagnostic structure

## Testing
- `R -e "devtools::test()"` *(fails: command not found)*