### PR TITLE
Include K_sl diagnostics

### DIFF
--- a/R/adaptive_ridge_projector.R
+++ b/R/adaptive_ridge_projector.R
@@ -23,7 +23,8 @@
 #' @param diagnostics Logical; return diagnostic information.
 #' @return A list with elements:
 #'   \item{Z_sl_raw}{Projected coefficients ((N*K) x V_sl).}
-#'   \item{diag_data}{List of diagnostic information if requested.}
+#'   \item{diag_data}{List of diagnostic information if requested. When
+#'     `diagnostics = TRUE`, this includes the searchlight projector `K_sl`.}
 #' @export
 adaptive_ridge_projector <- function(Y_sl,
                                      projector_components,
@@ -136,7 +137,8 @@ adaptive_ridge_projector <- function(Y_sl,
     dl <- list(lambda_sl_chosen = lambda_eff,
                lambda_sl_raw = lambda_sl_raw,
                s_n_sq = s_n_sq,
-               s_b_sq = s_b_sq)
+               s_b_sq = s_b_sq,
+               K_sl = K_sl)
     diag_list <- cap_diagnostics(dl)
   }
 

--- a/tests/testthat/test-adaptive-collapse.R
+++ b/tests/testthat/test-adaptive-collapse.R
@@ -12,6 +12,7 @@ test_that("adaptive_ridge_projector with method none works", {
   expect_equal(dim(res$Z_sl_raw), c(ncol(X), 2L))
   diag <- res$diag_data
   expect_true(!is.null(diag))
+  expect_equal(dim(diag$K_sl), dim(proj$K_global))
   expect_equal(diag$lambda_sl_chosen, 0.5)
 })
 
@@ -42,6 +43,7 @@ test_that("adaptive_ridge_projector EB works", {
   expect_equal(dim(res$Z_sl_raw), c(ncol(X), 2L))
   diag <- res$diag_data
   expect_true(!is.null(diag))
+  expect_equal(dim(diag$K_sl), dim(proj$K_global))
   expect_true(is.finite(diag$lambda_sl_chosen))
   expect_true(is.finite(diag$s_n_sq))
   expect_true(is.finite(diag$s_b_sq))
@@ -61,6 +63,7 @@ test_that("adaptive_ridge_projector LOOcv_local works", {
                                   X_theta_for_EB_residuals = X,
                                   diagnostics = TRUE)
   expect_equal(dim(res$Z_sl_raw), c(ncol(X), 2L))
+  expect_equal(dim(res$diag_data$K_sl), dim(proj$K_global))
   expect_true(is.finite(res$diag_data$lambda_sl_chosen))
 })
 


### PR DESCRIPTION
## Notes
- R not installed, so tests could not be executed.

## Summary
- document `K_sl` as part of diagnostic output
- capture searchlight projector `K_sl` when diagnostics are enabled
- verify presence of `K_sl` in adaptive ridge projector tests
