### PR TITLE
Improve projector checks and NA handling

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -47,16 +47,12 @@ fr_projector <- function(Qt, R, K_global = NULL) {
   if (!is.matrix(R)) {
     stop("R must be a matrix")
   }
-  if (nrow(Qt) != ncol(R)) {
-    stop("nrow(Qt) must equal ncol(R)")
-  }
+  stopifnot(nrow(Qt) == ncol(R))
   if (!is.null(K_global)) {
     if (!is.matrix(K_global)) {
       stop("K_global must be a matrix")
     }
-    if (!all(dim(K_global) == dim(Qt))) {
-      stop("K_global must have same dimensions as Qt")
-    }
+    stopifnot(all(dim(K_global) == dim(Qt)))
   }
   structure(
     list(Qt = Qt, R = R, K_global = K_global),

--- a/R/collapse_beta.R
+++ b/R/collapse_beta.R
@@ -30,9 +30,7 @@ collapse_beta <- function(Z_sl_raw, N_trials, K_hrf_bases,
     stop("method must be either 'rss', 'pc', or 'optim'")
   }
 
-  if (nrow(Z_sl_raw) != N_trials * K_hrf_bases) {
-    stop("nrow(Z_sl_raw) must equal N_trials * K_hrf_bases")
-  }
+  stopifnot(nrow(Z_sl_raw) == N_trials * K_hrf_bases)
 
   V_sl <- ncol(Z_sl_raw)
   A_sl <- matrix(0, nrow = N_trials, ncol = V_sl)
@@ -70,9 +68,7 @@ collapse_beta <- function(Z_sl_raw, N_trials, K_hrf_bases,
     if (is.null(classifier_for_w_optim) || is.null(labels_for_w_optim)) {
       stop("classifier_for_w_optim and labels_for_w_optim must be provided for method='optim'")
     }
-    if (length(labels_for_w_optim) != N_trials) {
-      stop("length(labels_for_w_optim) must equal N_trials")
-    }
+    stopifnot(length(labels_for_w_optim) == N_trials)
     Z_arr <- array(Z_sl_raw, dim = c(K_hrf_bases, N_trials, V_sl))
     fn_gr <- function(w) {
       A_tmp <- apply(Z_arr, c(2, 3), function(z) sum(z * w))

--- a/R/explain_projection_results.R
+++ b/R/explain_projection_results.R
@@ -37,10 +37,7 @@ explain_projection_results <- function(sl_results, mask_dims, hrf_basis_matrix =
     }
     if (!is.null(hrf_basis_matrix)) {
       w_mean <- rowMeans(w_mat)
-      if (ncol(hrf_basis_matrix) != length(w_mean)) {
-        stop("Number of columns in hrf_basis_matrix (", ncol(hrf_basis_matrix),
-             ") must match length of collapse weights (", length(w_mean), ")")
-      }
+      stopifnot(ncol(hrf_basis_matrix) == length(w_mean))
       effective_hrf <- as.numeric(hrf_basis_matrix %*% w_mean)
     }
   }

--- a/R/progressive_projection.R
+++ b/R/progressive_projection.R
@@ -70,10 +70,7 @@ predict_pp <- function(pp_model, A_sl_new) {
   if (!is.numeric(A_sl_new)) {
     stop("A_sl_new must be numeric")
   }
-  if (ncol(A_sl_new) != nrow(pp_model$W)) {
-    stop("Non-conformable matrices: ncol(A_sl_new) = ", ncol(A_sl_new),
-         " but nrow(pp_model$W) = ", nrow(pp_model$W))
-  }
+  stopifnot(ncol(A_sl_new) == nrow(pp_model$W))
   (A_sl_new %*% pp_model$W)[, , drop = FALSE]
 }
 


### PR DESCRIPTION
## Summary
- simplify dimension checks with `stopifnot`
- warn and return empty result when searchlight data has `NA`
- skip EB estimation when `T_obs <= m`
- expand unit tests for new behaviours

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*