### PR TITLE
Add LS+SVD HRF recovery example

### DIFF
--- a/fmrireg_cheatsheet.md
+++ b/fmrireg_cheatsheet.md
@@ -1,0 +1,20 @@
+# fmrireg Cheatsheet
+
+This cheatsheet summarizes useful functions from the `fmrireg` package used in the tests.
+
+## Key functions
+
+- `simulate_bold_signal(ncond, hrf, nreps, amps, isi, ampsd, TR)`
+  simulates BOLD responses for the provided HRF and returns a list with `onset` and `mat`.
+- `HRF_SPMG1`, `HRF_BSPLINE`, `HRF_TENT`
+  basis generating functions for modeling the hemodynamic response.
+
+## LS + SVD HRF recovery workflow
+
+1. Simulate data with `simulate_bold_signal` using a canonical HRF.
+2. Build a design matrix with `build_design_matrix`, supplying a flexible basis such as `HRF_BSPLINE` or `HRF_TENT`.
+3. Fit an ordinary least squares projector with `build_projector` to obtain trial-wise estimates.
+4. Reshape the estimates into a trial-by-basis matrix and apply `svd`.
+5. The first left singular vector approximates the underlying HRF shape and can be compared to the ground truth.
+
+See `tests/testthat/test-ls-svd-hrf-recovery.R` for an example.

--- a/tests/testthat/test-ls-svd-hrf-recovery.R
+++ b/tests/testthat/test-ls-svd-hrf-recovery.R
@@ -1,0 +1,39 @@
+context("ls+svd HRF recovery")
+
+test_that("LS+SVD recovers SPMG1 HRF using BSPLINE basis", {
+  if (!requireNamespace("fmrireg", quietly = TRUE)) {
+    skip("fmrireg not installed")
+  }
+
+  set.seed(123)
+  sim <- fmrireg::simulate_bold_signal(ncond = 1,
+                                       hrf = fmrireg::HRF_SPMG1,
+                                       nreps = 40,
+                                       isi = c(1, 3),
+                                       TR = 1)
+
+  time <- sim$mat[, 1]
+  bold <- sim$mat[, 2]
+
+  em <- list(onsets = as.integer(round(sim$onset)),
+             n_time = length(time),
+             basis_length = 30L)
+
+  X_obj <- build_design_matrix(em,
+                               hrf_basis_func = fmrireg::HRF_BSPLINE,
+                               theta_params = list(df = 10),
+                               sparse = FALSE)
+  X <- X_obj$X
+
+  proj <- build_projector(X, lambda_global = 0)
+  beta_hat <- drop(proj$K_global %*% bold)
+  nbasis <- ncol(X) / length(em$onsets)
+  beta_mat <- matrix(beta_hat, ncol = nbasis, byrow = TRUE)
+
+  sv <- svd(beta_mat)
+  hrf_est <- sv$u[, 1]
+  if (sum(hrf_est) < 0) hrf_est <- -hrf_est
+
+  true_hrf <- fmrireg::HRF_SPMG1(seq_along(hrf_est) - 1)
+  expect_gt(cor(hrf_est, true_hrf), 0.9)
+})


### PR DESCRIPTION
## Summary
- add cheatsheet for key fmrireg functions
- add test demonstrating LS+SVD HRF recovery using simulated data

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*