### PR TITLE
Add edge case coverage for utilities and projection

### DIFF
--- a/tests/testthat/test-cap-diagnostics.R
+++ b/tests/testthat/test-cap-diagnostics.R
@@ -1,0 +1,10 @@
+context("cap_diagnostics")
+
+test_that("cap_diagnostics discards large diagnostics", {
+  diag_list <- list(a = rnorm(100))
+  expect_warning(
+    res <- cap_diagnostics(diag_list, memory_limit = object.size(diag_list) - 10),
+    "Diagnostics exceed"
+  )
+  expect_null(res)
+})

--- a/tests/testthat/test-pp.R
+++ b/tests/testthat/test-pp.R
@@ -20,3 +20,10 @@ test_that("fit_pp and predict_pp work for PLS-DA", {
   expect_equal(ncol(proj), 1)
   expect_equal(nrow(proj), nrow(A))
 })
+
+test_that("fit_pp handles single class by returning identity", {
+  A <- matrix(rnorm(10), ncol = 2)
+  labels <- rep("a", nrow(A))
+  model <- fit_pp(A, labels, method = "LDA", dims = 2)
+  expect_equal(model$W, diag(ncol(A)))
+})


### PR DESCRIPTION
## Summary
- add `cap_diagnostics` test ensuring diagnostics are dropped when oversized
- check that `fit_pp` returns the identity projection when only one class is present

## Testing
- `R -q -e "devtools::test()"` *(fails: `bash: R: command not found`)*