### PR TITLE
Finalize MVPA API and documentation

### DIFF
--- a/R/api_run_analysis.R
+++ b/R/api_run_analysis.R
@@ -2,6 +2,8 @@
 #'
 #' High-level wrapper that automatically builds the necessary
 #' `rMVPA` objects and connects them to the fmriproj projection pipeline.
+#' See the vignette "Running rMVPA Analyses on Time-Series Data" for a
+#' complete walkthrough.
 #'
 #' @param Y Time-series matrix (time x voxels)
 #' @param event_model Event model list describing trial onsets and labels
@@ -77,7 +79,8 @@ run_searchlight <- function(Y,
 #' Run MVPA on a single region of interest
 #'
 #' This function mirrors `run_searchlight()` but operates on a predefined
-#' region mask instead of iterating searchlights.
+#' region mask instead of iterating searchlights. See the vignette
+#' "Running rMVPA Analyses on Time-Series Data" for usage examples.
 #'
 #' @inheritParams run_searchlight
 #' @param region_mask Logical vector or matrix defining the region of interest

--- a/R/user_friendly_wrappers.R
+++ b/R/user_friendly_wrappers.R
@@ -1,5 +1,10 @@
 #' Project trials from time-series data
 #'
+#' \strong{Deprecated}. The high-level [`run_regional()`] function now
+#' provides a more flexible interface for projecting trial patterns from
+#' time-series data. `project_trials()` remains as a thin helper around the
+#' core projection steps but will be removed in a future release.
+#'
 #' A user-friendly wrapper that handles the complete projection pipeline
 #' in one function call. This is the simplest way to get trial patterns
 #' from fMRI time-series data.
@@ -12,6 +17,7 @@
 #' @param verbose Print progress messages
 #' @return Matrix of trial patterns (trials x voxels)
 #' @export
+#' @deprecated Use `run_regional()` for single-ROI analyses.
 #' @examples
 #' # Simple usage
 #' trial_patterns <- project_trials(bold_data, event_model)
@@ -19,12 +25,14 @@
 #' # With adaptive regularization
 #' trial_patterns <- project_trials(bold_data, event_model, 
 #'                                  lambda_method = "EB")
-project_trials <- function(Y, 
+project_trials <- function(Y,
                           event_model,
                           lambda_method = c("EB", "none", "CV"),
                           collapse_method = c("rss", "pc", "optim"),
                           hrf_basis = NULL,
                           verbose = TRUE) {
+
+  .Deprecated("run_regional")
   
   lambda_method <- match.arg(lambda_method)
   collapse_method <- match.arg(collapse_method)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ remotes::install_github("bbuchsbaum/fmriproj")
 - `build_design_matrix()`: Constructs trial-wise design matrices
 - `adaptive_ridge_projector()`: Performs adaptive ridge projection
 - `collapse_beta()`: Implements beta coefficient collapse strategies
-- `run_searchlight_projected()`: Runs projected MVPA searchlight analysis
+- `run_searchlight()`: Run a projected searchlight MVPA analysis
+- `run_regional()`: Run a projected ROI-based MVPA analysis
 - `optimize_hrf_mvpa()`: Optimizes HRF parameters for MVPA performance
 
 ### Gradient computation

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,4 +30,6 @@ navbar:
       text: Articles
       menu:
       - text: Getting Started
-        href: articles/getting-started.html 
+        href: articles/getting-started.html
+      - text: Running rMVPA on Time-Series
+        href: articles/running-rmvpa-time-series.html

--- a/vignettes/running-rmvpa-time-series.Rmd
+++ b/vignettes/running-rmvpa-time-series.Rmd
@@ -1,0 +1,136 @@
+---
+title: "Running rMVPA Analyses on Time-Series Data"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Running rMVPA Analyses on Time-Series Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Overview
+
+This article demonstrates the streamlined interface for running multivariate
+pattern analyses directly from fMRI time-series data. The high level
+functions `run_searchlight()` and `run_regional()` wrap the full
+projection pipeline and automatically create all required `rMVPA` objects.
+
+We assume you have already installed **fmriproj**, **fmrireg** and
+**rMVPA** from GitHub.
+
+```{r eval=FALSE}
+# Install packages
+remotes::install_github("bbuchsbaum/fmrireg")
+remotes::install_github("bbuchsbaum/rMVPA")
+remotes::install_github("bbuchsbaum/fmriproj")
+```
+
+```{r setup}
+library(fmriproj)
+library(fmrireg)
+library(rMVPA)
+```
+
+## Basic Searchlight Example
+
+Starting from a time-series matrix `Y` (time \* voxels) and an event
+model describing your trials, a whole-brain searchlight analysis can be
+run in a single call:
+
+```{r searchlight-simple, eval=FALSE}
+# Y           : time x voxels matrix
+# events      : data frame with onsets and conditions
+# brain_mask  : logical vector or matrix
+
+event_model <- fmrireg::event_model(
+  onsets     = events$onset,
+  conditions = events$condition,
+  blocks     = events$run
+)
+
+sl_result <- run_searchlight(
+  Y            = Y,
+  event_model  = event_model,
+  mask         = brain_mask,
+  radius       = 3,
+  classifier   = "sda_notune"
+)
+```
+
+The returned object is an `rMVPA::searchlight_result` containing
+accuracy maps and optional diagnostics.
+
+## Running a Regional Analysis
+
+For a single region of interest the `run_regional()` function mirrors
+`run_searchlight()`:
+
+```{r regional-simple, eval=FALSE}
+roi_result <- run_regional(
+  Y            = Y,
+  event_model  = event_model,
+  region_mask  = roi_mask,
+  classifier   = "sda_notune"
+)
+```
+
+## Customising Projection Options
+
+Both high level functions accept a `projection_opts` list to control
+regularisation and HRF collapse methods:
+
+```{r opts-example, eval=FALSE}
+opts <- list(
+  lambda_adaptive_method = "CV",
+  collapse_method        = "pc",
+  lambda_global          = 0.2
+)
+
+sl_cv <- run_searchlight(
+  Y, event_model, mask = brain_mask,
+  projection_opts = opts
+)
+```
+
+## Progressive Projection as Feature Selection
+
+`rMVPA` feature selectors can be combined with the projection framework.
+The helper `pp_feature_selector()` attaches a progressive projection step
+before classification:
+
+```{r pp-example, eval=FALSE}
+model <- rMVPA::mvpa_model(
+  model   = rMVPA::load_model("sda_notune"),
+  dataset = rMVPA::mvpa_dataset(Y, brain_mask),
+  design  = rMVPA::mvpa_design(event_model$conditions)
+)
+
+model$feature_selector <- pp_feature_selector(dims = 5)
+
+pp_result <- run_searchlight(
+  Y, event_model, brain_mask,
+  classifier = "sda_notune",
+  projection_opts = list(),
+  cross_validation = NULL
+)
+```
+
+## Interpreting Results and Diagnostics
+
+The `searchlight_result` and `regional_mvpa_result` objects contain
+performance values and optional diagnostic information about the
+projection step. Functions such as `plot_searchlight_diagnostics()` can
+visualise adaptive lambda values or HRF weights for a given voxel.
+
+```{r diag-example, eval=FALSE}
+plot_searchlight_diagnostics(pp_result, voxel = 100, plot_type = "lambda")
+```
+
+Refer to the package documentation for further details.
+


### PR DESCRIPTION
## Summary
- deprecate `project_trials` helper
- reference new vignette in high-level API docs
- add vignette "Running rMVPA Analyses on Time-Series Data"
- update pkgdown config and README to point to new functions

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684434329fb0832dbbd798a365ae2dad