### PR TITLE
Implement fmridataset bridge helpers

### DIFF
--- a/R/fmridataset_bridge.R
+++ b/R/fmridataset_bridge.R
@@ -1,0 +1,57 @@
+#' Create rMVPA design from an fmridataset
+#'
+#' Internal helper that extracts label and block information from the
+#' `event_table` of an `fmridataset` and constructs an `rMVPA::mvpa_design`
+#' object.
+#'
+#' @param fmri_dset An object of class `fmri_dataset`.
+#' @param y_formula Formula selecting the label column from `event_table`.
+#' @param block_formula Formula selecting the block/run column.
+#'
+#' @return An `mvpa_design` object.
+#' @keywords internal
+create_mvpa_design_from_dataset <- function(fmri_dset,
+                                            y_formula,
+                                            block_formula) {
+  if (!requireNamespace("rMVPA", quietly = TRUE)) {
+    stop("rMVPA package required. Install with: devtools::install_github('bbuchsbaum/rMVPA')")
+  }
+
+  if (!inherits(y_formula, "formula")) {
+    stop("y_formula must be a formula")
+  }
+  if (!inherits(block_formula, "formula")) {
+    stop("block_formula must be a formula")
+  }
+
+  et <- fmri_dset$event_table
+  if (is.null(et)) {
+    stop("fmri_dset must contain an event_table")
+  }
+
+  y_vals <- model.frame(y_formula, et, drop.unused.levels = TRUE)[[1]]
+  block_vals <- model.frame(block_formula, et, drop.unused.levels = TRUE)[[1]]
+
+  rMVPA::mvpa_design(y_train = y_vals, block_var = block_vals)
+}
+
+#' Create rMVPA dataset from an fmridataset
+#'
+#' Internal helper that extracts the time-series `NeuroVec` and mask from an
+#' `fmridataset` and constructs an `rMVPA::mvpa_dataset` object.
+#'
+#' @param fmri_dset An object of class `fmri_dataset`.
+#'
+#' @return An `mvpa_dataset` object.
+#' @keywords internal
+create_mvpa_dataset_from_dataset <- function(fmri_dset) {
+  if (!requireNamespace("rMVPA", quietly = TRUE)) {
+    stop("rMVPA package required. Install with: devtools::install_github('bbuchsbaum/rMVPA')")
+  }
+
+  Y <- fmridataset::get_data(fmri_dset)
+  mask <- fmridataset::get_mask(fmri_dset)
+
+  rMVPA::mvpa_dataset(Y, mask)
+}
+

--- a/tests/testthat/test-fmridataset-bridge.R
+++ b/tests/testthat/test-fmridataset-bridge.R
@@ -1,0 +1,21 @@
+context("fmridataset bridge")
+
+# Minimal mock dataset with required structure
+mock_dset <- list(event_table = data.frame(y = 1:2, block = c(1,1)))
+class(mock_dset) <- "fmri_dataset"
+
+# These helpers require rMVPA, so they should error when the package is missing
+
+test_that("create_mvpa_design_from_dataset errors without rMVPA", {
+  expect_error(
+    create_mvpa_design_from_dataset(mock_dset, ~y, ~block),
+    "rMVPA package required"
+  )
+})
+
+test_that("create_mvpa_dataset_from_dataset errors without rMVPA", {
+  expect_error(
+    create_mvpa_dataset_from_dataset(mock_dset),
+    "rMVPA package required"
+  )
+})


### PR DESCRIPTION
## Summary
- implement helper functions to create mvpa objects from `fmridataset`
- add tests verifying error when `rMVPA` is missing

## Testing
- `R CMD --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443a7b0b94832dbde3143b143b2015