### PR TITLE
Update docs for fmridataset workflow

### DIFF
--- a/R/api_run_analysis.R
+++ b/R/api_run_analysis.R
@@ -15,6 +15,25 @@
 #' @param ... Additional arguments passed to `rMVPA::run_searchlight`
 #'
 #' @return An object of class `searchlight_result`
+#' @examples
+#' ## create a simple in-memory dataset
+#' Y <- matrix(rnorm(1000), nrow = 100)
+#' mask <- rep(TRUE, 10)
+#' events <- data.frame(
+#'   onset = seq(1, 100, by = 5),
+#'   condition = rep(c("A", "B"), each = 10),
+#'   run = 1
+#' )
+#' dset <- fmridataset::matrix_dataset(
+#'   Y, mask = mask,
+#'   event_table = events,
+#'   sampling_frame = data.frame(block = 1, blocklens = nrow(Y))
+#' )
+#' sl <- run_searchlight(
+#'   dset, radius = 2,
+#'   y_formula = ~condition,
+#'   block_formula = ~run
+#' )
 #' @export
 run_searchlight <- function(fmri_dset,
                             radius = 3,
@@ -107,6 +126,26 @@ run_searchlight <- function(fmri_dset,
 #' @param ... Additional arguments passed to `rMVPA::run_regional`
 #'
 #' @return An object of class `regional_mvpa_result`
+#' @examples
+#' ## create a dataset and region mask
+#' Y <- matrix(rnorm(1000), nrow = 100)
+#' mask <- rep(TRUE, 10)
+#' roi  <- mask
+#' events <- data.frame(
+#'   onset = seq(1, 100, by = 5),
+#'   condition = rep(c("A", "B"), each = 10),
+#'   run = 1
+#' )
+#' dset <- fmridataset::matrix_dataset(
+#'   Y, mask = mask,
+#'   event_table = events,
+#'   sampling_frame = data.frame(block = 1, blocklens = nrow(Y))
+#' )
+#' res <- run_regional(
+#'   dset, region_mask = roi,
+#'   y_formula = ~condition,
+#'   block_formula = ~run
+#' )
 #' @export
 run_regional <- function(fmri_dset,
                          region_mask,

--- a/R/user_friendly_wrappers.R
+++ b/R/user_friendly_wrappers.R
@@ -94,6 +94,8 @@ project_trials <- function(Y,
 
 #' Run MVPA searchlight analysis with projection
 #'
+#' @deprecated Use `run_searchlight()` with an `fmridataset`.
+#'
 #' High-level wrapper that combines projection with rMVPA searchlight analysis.
 #' Handles all the integration details automatically.
 #'
@@ -108,13 +110,14 @@ project_trials <- function(Y,
 #' @return Searchlight results with performance maps
 #' @export
 mvpa_searchlight <- function(Y,
-                            event_model, 
+                            event_model,
                             mask,
                             radius = 3,
                             classifier = "sda_notune",
                             cross_validation = NULL,
                             projection_opts = list(),
                             n_cores = 1) {
+  .Deprecated("run_searchlight")
   
   # Check dependencies
   if (!requireNamespace("rMVPA", quietly = TRUE)) {

--- a/vignettes/unified-workflow.Rmd
+++ b/vignettes/unified-workflow.Rmd
@@ -1,0 +1,67 @@
+---
+title: "A Unified Workflow: From fmridataset to MVPA Results"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{A Unified Workflow: From fmridataset to MVPA Results}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Overview
+
+This vignette demonstrates the streamlined analysis pipeline using
+`fmridataset` objects with `fmriproj`. A single dataset encapsulates the
+time-series, mask and event information which is then passed directly to
+`run_searchlight()` or `run_regional()`.
+
+## Creating an fmridataset
+
+```{r}
+# simulate small data for illustration
+Y <- matrix(rnorm(1000), nrow = 100)
+mask <- rep(TRUE, 10)
+events <- data.frame(
+  onset = seq(1, 100, by = 5),
+  condition = rep(c("A", "B"), each = 10),
+  run = 1
+)
+
+library(fmridataset)
+dset <- matrix_dataset(
+  Y, mask = mask,
+  event_table = events,
+  sampling_frame = data.frame(block = 1, blocklens = nrow(Y))
+)
+```
+
+## Running a Searchlight Analysis
+
+```{r eval=FALSE}
+sl_res <- fmriproj::run_searchlight(
+  dset,
+  radius = 2,
+  y_formula = ~condition,
+  block_formula = ~run
+)
+```
+
+## Running a Regional Analysis
+
+```{r eval=FALSE}
+roi_res <- fmriproj::run_regional(
+  dset,
+  region_mask = mask,
+  y_formula = ~condition,
+  block_formula = ~run
+)
+```
+
+Both functions automatically perform trial projection and interface
+with `rMVPA` to produce MVPA results.


### PR DESCRIPTION
## Summary
- deprecate `mvpa_searchlight` wrapper
- document `run_searchlight` and `run_regional` usage with `fmridataset`
- add a new vignette on the unified workflow

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443f063e18832d9a96c6c308efd84a