### PR TITLE
Add coverage tests for data validation and diagnostics

### DIFF
--- a/tests/testthat/test-check-data-compatibility.R
+++ b/tests/testthat/test-check-data-compatibility.R
@@ -1,0 +1,10 @@
+context("check_data_compatibility")
+
+test_that("check_data_compatibility errors when event_model lacks onsets", {
+  Y <- matrix(0, nrow = 5, ncol = 3)
+  event_model <- list()  # missing onsets
+  expect_error(
+    check_data_compatibility(Y, event_model),
+    "event_model missing required fields"
+  )
+})

--- a/tests/testthat/test-plot-searchlight-diagnostics.R
+++ b/tests/testthat/test-plot-searchlight-diagnostics.R
@@ -1,0 +1,10 @@
+context("plot_searchlight_diagnostics")
+
+test_that("plot_searchlight_diagnostics errors when ggplot2 is missing", {
+  results <- list(diagnostics = list(list(lambda_sl = 0.5, w_sl = c(1, 2))))
+  get_searchlight_index <- function(results, voxel) 1
+  expect_error(
+    plot_searchlight_diagnostics(results, voxel = 1),
+    "ggplot2 required for plotting"
+  )
+})


### PR DESCRIPTION
## Summary
- add test for `check_data_compatibility` error handling when `onsets` are missing
- add test for `plot_searchlight_diagnostics` when `ggplot2` is unavailable

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448ea5c4c8832dba38eb356ffc1bd7