### PR TITLE
Add coverage tests

### DIFF
--- a/tests/testthat/test-check-data-compatibility.R
+++ b/tests/testthat/test-check-data-compatibility.R
@@ -8,3 +8,24 @@ test_that("check_data_compatibility errors when event_model lacks onsets", {
     "event_model missing required fields"
   )
 })
+
+test_that("check_data_compatibility validates Y input and timing", {
+  Y <- matrix(0, nrow = 4, ncol = 2)
+  em_ok <- list(onsets = c(0, 3))
+
+  # Y must be a matrix
+  expect_error(check_data_compatibility(1:4, em_ok), "Y must be a matrix")
+
+  # Last onset cannot exceed scan duration
+  em_bad <- list(onsets = c(0, 10))
+  expect_error(
+    check_data_compatibility(Y, em_bad, TR = 2),
+    "exceeds scan duration"
+  )
+
+  # Closely spaced trials trigger a warning
+  expect_warning(
+    check_data_compatibility(Y, em_ok, TR = 2),
+    "Trials may be too close"
+  )
+})

--- a/tests/testthat/test-project-trials.R
+++ b/tests/testthat/test-project-trials.R
@@ -1,0 +1,17 @@
+context("project_trials")
+
+test_that("project_trials runs complete pipeline", {
+  Y <- matrix(1, nrow = 6, ncol = 1)
+  em <- list(onsets = c(0L, 2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  res <- suppressWarnings(
+    project_trials(Y, em,
+                   lambda_method = "none",
+                   collapse_method = "rss",
+                   hrf_basis = basis,
+                   verbose = FALSE)
+  )
+  expect_equal(dim(res), c(length(em$onsets), ncol(Y)))
+  expect_true(all(res >= 0))
+})


### PR DESCRIPTION
## Summary
- test input validation and timing warnings in `check_data_compatibility`
- add regression test covering deprecated `project_trials` pipeline

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448f6f5ba0832d8388fe8da5dd4f7b