### PR TITLE
Add searchlight diagnostics helper

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -30,6 +30,7 @@ export(project_trials)
 export(mvpa_searchlight)
 export(check_data_compatibility)
 export(plot_searchlight_diagnostics)
+export(get_searchlight_index)
 
 # rMVPA compatibility functions
 export(make_rmvpa_searchlight_fun)

--- a/R/user_friendly_wrappers.R
+++ b/R/user_friendly_wrappers.R
@@ -285,7 +285,9 @@ check_data_compatibility <- function(Y, event_model, TR = NULL) {
 #' Visualize diagnostic information for a specific searchlight to understand
 #' the projection process.
 #'
-#' @param results Results object with diagnostics
+#' @param results Results object containing a `diagnostics` list with one
+#'   entry per searchlight. If a vector `voxel_indices` is present it is used
+#'   to map voxels to diagnostic entries.
 #' @param voxel Central voxel index
 #' @param plot_type Type of plot: "weights", "lambda", "patterns"
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,3 +6,33 @@ cap_diagnostics <- function(diag_list, memory_limit = getOption("fmriproj.diagno
   }
   diag_list
 }
+
+#' Get index of searchlight diagnostics for a voxel
+#'
+#' Searchlight result objects produced by fmriproj store per-searchlight
+#' diagnostic information in `results$diagnostics`. The optional
+#' `voxel_indices` vector specifies which voxel belongs to each entry in
+#' that list. When `voxel_indices` is absent, diagnostics are assumed to
+#' be ordered by voxel index.
+#'
+#' @param results Searchlight results containing a `diagnostics` list and
+#'   optionally a `voxel_indices` vector identifying the central voxel of
+#'   each searchlight.
+#' @param voxel Voxel index whose diagnostics should be retrieved.
+#' @return Integer index into `results$diagnostics` corresponding to the
+#'   requested voxel.
+#' @export
+get_searchlight_index <- function(results, voxel) {
+  if (!is.null(results$voxel_indices)) {
+    idx <- match(voxel, results$voxel_indices)
+    if (is.na(idx)) {
+      stop("Voxel not found in results$voxel_indices")
+    }
+    return(idx)
+  }
+  idx <- as.integer(voxel)
+  if (idx < 1 || idx > length(results$diagnostics)) {
+    stop("Voxel index out of range for diagnostics")
+  }
+  idx
+}

--- a/tests/testthat/test-plot-searchlight-diagnostics.R
+++ b/tests/testthat/test-plot-searchlight-diagnostics.R
@@ -2,9 +2,29 @@ context("plot_searchlight_diagnostics")
 
 test_that("plot_searchlight_diagnostics errors when ggplot2 is missing", {
   results <- list(diagnostics = list(list(lambda_sl = 0.5, w_sl = c(1, 2))))
-  get_searchlight_index <- function(results, voxel) 1
   expect_error(
     plot_searchlight_diagnostics(results, voxel = 1),
     "ggplot2 required for plotting"
   )
+})
+
+test_that("get_searchlight_index uses voxel_indices", {
+  res <- list(
+    diagnostics = list(
+      list(lambda_sl = 0.5, w_sl = c(1,2)),
+      list(lambda_sl = 0.6, w_sl = c(3,4))
+    ),
+    voxel_indices = c(10, 20)
+  )
+  expect_equal(get_searchlight_index(res, 20), 2L)
+})
+
+test_that("plot_searchlight_diagnostics returns ggplot", {
+  skip_if_not_installed("ggplot2")
+  res <- list(
+    diagnostics = list(list(lambda_sl = 0.5, w_sl = c(1,2))),
+    voxel_indices = 5
+  )
+  p <- plot_searchlight_diagnostics(res, voxel = 5, plot_type = "weights")
+  expect_s3_class(p, "ggplot")
 })


### PR DESCRIPTION
## Summary
- implement `get_searchlight_index()` utility
- document `results` structure in `plot_searchlight_diagnostics`
- export new helper in NAMESPACE
- expand tests for plotting diagnostics using helper

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d607df84832da8cdd203da21f5e0