### PR TITLE
Add lambda_global parameter to project_trials

### DIFF
--- a/tests/testthat/test-project-trials.R
+++ b/tests/testthat/test-project-trials.R
@@ -15,3 +15,27 @@ test_that("project_trials runs complete pipeline", {
   expect_equal(dim(res), c(length(em$onsets), ncol(Y)))
   expect_true(all(res >= 0))
 })
+
+test_that("project_trials honors custom lambda_global", {
+  set.seed(1)
+  Y <- matrix(rnorm(6), nrow = 6, ncol = 1)
+  em <- list(onsets = c(0L, 2L), n_time = 6L)
+  basis <- matrix(c(1,0,0,
+                    0,1,0), nrow = 3, byrow = FALSE)
+  res_default <- suppressWarnings(
+    project_trials(Y, em,
+                   lambda_method = "none",
+                   collapse_method = "rss",
+                   hrf_basis = basis,
+                   verbose = FALSE)
+  )
+  res_custom <- suppressWarnings(
+    project_trials(Y, em,
+                   lambda_method = "none",
+                   collapse_method = "rss",
+                   lambda_global = 1,
+                   hrf_basis = basis,
+                   verbose = FALSE)
+  )
+  expect_false(isTRUE(all.equal(res_default, res_custom)))
+})


### PR DESCRIPTION
## Summary
- expose `lambda_global` in `project_trials`
- validate and pass it through to projector functions
- document new parameter
- add test verifying custom global penalty is used

## Testing
- `R CMD check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d60e8fb8832d83f3b520aeab9bf3