### PR TITLE
Refactor messaging

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -3,6 +3,7 @@
 #' Simple summaries of `fr_design_matrix` and `fr_projector` objects.
 #'
 #' @param x Object to print.
+#' @param quiet Logical; suppress messages if `TRUE`.
 #' @param ... Additional arguments ignored.
 #' @return Invisibly returns `x`.
 #' @name print_methods
@@ -10,36 +11,37 @@ NULL
 
 #' @rdname print_methods
 #' @export
-print.fr_design_matrix <- function(x, ...) {
+print.fr_design_matrix <- function(x, quiet = FALSE, ...) {
   dims <- dim(x$X)
-  cat("fr_design_matrix\n")
-  cat(" - X dims:", dims[1], "x", dims[2])
-  if (inherits(x$X, "dgCMatrix")) cat(" [sparse]\n") else cat(" [dense]\n")
-  if (is.null(x$event_model)) {
-    cat(" - event_model: none\n")
-  } else {
-    cat(" - event_model present\n")
-  }
-  invisible(x)
+  lines <- c(
+    "fr_design_matrix",
+    sprintf(" - X dims: %d x %d%s",
+            dims[1], dims[2],
+            if (inherits(x$X, 'dgCMatrix')) " [sparse]" else " [dense]"),
+    if (is.null(x$event_model)) " - event_model: none" else " - event_model present"
+  )
+  if (!quiet) message(paste(lines, collapse = "\n"))
+  invisible(lines)
 }
 
 #' @rdname print_methods
 #' @export
-print.fr_projector <- function(x, ...) {
-  cat("fr_projector\n")
+print.fr_projector <- function(x, quiet = FALSE, ...) {
+  lines <- "fr_projector"
   if (!is.null(x$Qt)) {
     dQt <- dim(x$Qt)
-    cat(" - Qt dims:", dQt[1], "x", dQt[2], "\n")
+    lines <- c(lines, sprintf(" - Qt dims: %d x %d", dQt[1], dQt[2]))
   }
   if (!is.null(x$R)) {
     dR <- dim(x$R)
-    cat(" - R dims:", dR[1], "x", dR[2], "\n")
+    lines <- c(lines, sprintf(" - R dims: %d x %d", dR[1], dR[2]))
   }
   if (is.null(x$K_global)) {
-    cat(" - K_global: none\n")
+    lines <- c(lines, " - K_global: none")
   } else {
     dK <- dim(x$K_global)
-    cat(" - K_global dims:", dK[1], "x", dK[2], "\n")
+    lines <- c(lines, sprintf(" - K_global dims: %d x %d", dK[1], dK[2]))
   }
-  invisible(x)
+  if (!quiet) message(paste(lines, collapse = "\n"))
+  invisible(lines)
 }

--- a/R/user_friendly_wrappers.R
+++ b/R/user_friendly_wrappers.R
@@ -190,9 +190,10 @@ mvpa_searchlight <- function(Y,
 #' @param Y Time-series data
 #' @param event_model Event model
 #' @param TR Repetition time in seconds
+#' @param quiet Logical; suppress messages if `TRUE`.
 #' @return Invisible TRUE if all checks pass, otherwise errors/warnings
 #' @export
-check_data_compatibility <- function(Y, event_model, TR = NULL) {
+check_data_compatibility <- function(Y, event_model, TR = NULL, quiet = FALSE) {
   
   # Check dimensions
   if (!is.matrix(Y) && !inherits(Y, "Matrix")) {
@@ -202,9 +203,11 @@ check_data_compatibility <- function(Y, event_model, TR = NULL) {
   n_time <- nrow(Y)
   n_voxels <- ncol(Y)
   
-  cat("Data dimensions:\n")
-  cat("  Time points:", n_time, "\n")
-  cat("  Voxels:", n_voxels, "\n")
+  if (!quiet) {
+    message("Data dimensions:")
+    message("  Time points: ", n_time)
+    message("  Voxels: ", n_voxels)
+  }
   
   # Check event model
   if (!is.list(event_model)) {
@@ -218,8 +221,10 @@ check_data_compatibility <- function(Y, event_model, TR = NULL) {
   }
   
   n_trials <- length(event_model$onsets)
-  cat("\nEvent model:\n")
-  cat("  Trials:", n_trials, "\n")
+  if (!quiet) {
+    message("\nEvent model:")
+    message("  Trials: ", n_trials)
+  }
   
   # Check timing
   if (!is.null(TR)) {
@@ -235,7 +240,7 @@ check_data_compatibility <- function(Y, event_model, TR = NULL) {
     trial_spacing <- diff(sort(event_model$onsets))
     min_spacing <- min(trial_spacing)
     
-    cat("  Min trial spacing:", round(min_spacing, 1), "s\n")
+    if (!quiet) message("  Min trial spacing: ", round(min_spacing, 1), "s")
     
     if (min_spacing < 2 * TR) {
       warning("Trials may be too close together for reliable separation")
@@ -245,8 +250,10 @@ check_data_compatibility <- function(Y, event_model, TR = NULL) {
   # Check conditions if provided
   if (!is.null(event_model$conditions)) {
     n_conditions <- length(unique(event_model$conditions))
-    cat("  Conditions:", n_conditions, "\n")
-    print(table(event_model$conditions))
+    if (!quiet) {
+      message("  Conditions: ", n_conditions)
+      print(table(event_model$conditions))
+    }
   }
   
   # Check for common issues
@@ -259,20 +266,24 @@ check_data_compatibility <- function(Y, event_model, TR = NULL) {
   }
   
   # Test basic projection
-  cat("\nTesting projection pipeline...")
+  if (!quiet) message("\nTesting projection pipeline...")
   
   test_result <- tryCatch({
     small_test <- project_trials(
-      Y[, 1:min(100, n_voxels)], 
+      Y[, 1:min(100, n_voxels)],
       event_model,
       verbose = FALSE
     )
-    cat(" SUCCESS\n")
-    cat("  Output dimensions:", dim(test_result), "\n")
+    if (!quiet) {
+      message(" SUCCESS")
+      message("  Output dimensions: ", paste(dim(test_result), collapse = " "))
+    }
     TRUE
   }, error = function(e) {
-    cat(" FAILED\n")
-    cat("  Error:", e$message, "\n")
+    if (!quiet) {
+      message(" FAILED")
+      message("  Error: ", e$message)
+    }
     FALSE
   })
   

--- a/tests/testthat/test-check-data-compatibility.R
+++ b/tests/testthat/test-check-data-compatibility.R
@@ -29,3 +29,10 @@ test_that("check_data_compatibility validates Y input and timing", {
     "Trials may be too close"
   )
 })
+
+test_that("quiet suppresses messages", {
+  Y <- matrix(0, nrow = 4, ncol = 2)
+  em <- list(onsets = c(0, 1))
+  expect_message(check_data_compatibility(Y, em, quiet = FALSE), "Data dimensions")
+  expect_message(check_data_compatibility(Y, em, quiet = TRUE), regexp = NA)
+})

--- a/tests/testthat/test-print-methods.R
+++ b/tests/testthat/test-print-methods.R
@@ -5,7 +5,7 @@ test_that("print.fr_design_matrix outputs summary", {
   basis <- matrix(c(1,0,0,
                     0,1,0), nrow = 3, byrow = FALSE)
   dm <- build_design_matrix(em, hrf_basis_matrix = basis)
-  expect_snapshot_output(print(dm))
+  expect_snapshot_output(cat(print(dm, quiet = TRUE), sep = "\n"))
 })
 
 test_that("print.fr_projector outputs summary", {
@@ -14,5 +14,5 @@ test_that("print.fr_projector outputs summary", {
                     0,1,0), nrow = 3, byrow = FALSE)
   dm <- build_design_matrix(em, hrf_basis_matrix = basis)
   proj <- build_projector(dm$X)
-  expect_snapshot_output(print(proj))
+  expect_snapshot_output(cat(print(proj, quiet = TRUE), sep = "\n"))
 })


### PR DESCRIPTION
## Summary
- replace `cat()` usage with `message()` in exported functions
- add `quiet` parameter to `check_data_compatibility`
- support `quiet` for print methods
- update docs and tests

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6124780832da72e60d9a6838cb8