### PR TITLE
Add NA validation to build_projector

### DIFF
--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -19,6 +19,9 @@ build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE,
   if (!inherits(X_theta, c("matrix", "Matrix"))) {
     stop("X_theta must be a matrix or Matrix")
   }
+  if (anyNA(X_theta)) {
+    stop("X_theta must not contain missing values")
+  }
   if (!is.numeric(lambda_global) || length(lambda_global) != 1 ||
       lambda_global < 0) {
     stop("lambda_global must be a single non-negative numeric value")

--- a/tests/testthat/test-build-projector.R
+++ b/tests/testthat/test-build-projector.R
@@ -131,3 +131,8 @@ test_that("build_projector validates inputs", {
                "lambda_global must be")
 
 })
+
+test_that("build_projector errors on NA values", {
+  X <- matrix(c(1, NA, 0, 1), nrow = 2)
+  expect_error(build_projector(X), "X_theta must not contain missing values")
+})


### PR DESCRIPTION
## Summary
- ensure `build_projector()` rejects matrices with missing values
- test NA handling

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6626c80832dbd14fbe5fa2a623c