### PR TITLE
Avoid redundant crossprod

### DIFF
--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -39,9 +39,7 @@ build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE,
   }
 
   if (lambda_global > 0) {
-    RtR <- crossprod(R)
     diag(RtR) <- diag(RtR) + lambda_global
-    tRQt <- t(R) %*% Qt
     cho <- chol(RtR)
     K_global <- backsolve(cho, backsolve(cho, tRQt, transpose = TRUE))
 


### PR DESCRIPTION
## Summary
- compute `crossprod` and `t(R) %*% Qt` once before the ridge branch
- modify `RtR` directly inside ridge branch

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d66c5cf4832db28a4ccfcc87deae