### PR TITLE
Update OLS projector computation

### DIFF
--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -47,7 +47,7 @@ build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE,
 
   } else {
     K_global <- tryCatch(
-      solve(R, Qt),
+      backsolve(R, Qt, upper = TRUE),
       error = function(e) MASS::ginv(R) %*% Qt
     )
   }

--- a/repomix-output.xml
+++ b/repomix-output.xml
@@ -3512,7 +3512,7 @@ build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE,
 
   } else {
     K_global <- tryCatch(
-      solve(R, Qt),
+      backsolve(R, Qt, upper = TRUE),
       error = function(e) MASS::ginv(R) %*% Qt
     )
   }
@@ -3603,7 +3603,7 @@ test_that("lambda_global 0 returns OLS projector", {
   if (!is.null(pivot_idx) && any(pivot_idx != seq_len(ncol(R)))) {
     R <- R[, order(pivot_idx), drop = FALSE]
   }
-  K_exp <- solve(R, Qt)
+  K_exp <- backsolve(R, Qt, upper = TRUE)
   expect_equal(proj$K_global, K_exp)
 })
 

--- a/tests/testthat/test-build-projector.R
+++ b/tests/testthat/test-build-projector.R
@@ -15,7 +15,7 @@ test_that("build_projector sparse QR works", {
   }
   expect_equal(proj$Qt, Qt_exp)
   expect_equal(proj$R, R_exp)
-  K_exp <- solve(R_exp, Qt_exp)
+  K_exp <- backsolve(R_exp, Qt_exp, upper = TRUE)
   expect_equal(proj$K_global, K_exp)
   expect_equal(as.matrix(proj$RtR), crossprod(R_exp))
   expect_equal(as.matrix(proj$tRQt), t(R_exp) %*% Qt_exp)
@@ -68,7 +68,7 @@ test_that("lambda_global 0 returns OLS projector", {
   if (!is.null(pivot_idx) && any(pivot_idx != seq_len(ncol(R)))) {
     R <- R[, order(pivot_idx), drop = FALSE]
   }
-  K_exp <- solve(R, Qt)
+  K_exp <- backsolve(R, Qt, upper = TRUE)
   expect_equal(proj$K_global, K_exp)
 })
 


### PR DESCRIPTION
## Summary
- improve `build_projector()` by solving with `backsolve()` when `lambda_global` is 0
- adjust tests to use `backsolve()`
- keep generated documentation up to date

## Testing
- `R -q -e "devtools::test(quiet = TRUE)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6694ad4832d9268f229b2929aca