### PR TITLE
Update build_projector docs

### DIFF
--- a/R/build_projector.R
+++ b/R/build_projector.R
@@ -12,7 +12,9 @@
 #'   \code{R}, \code{K_global}, and precomputed matrices \code{RtR} and
 #'   \code{tRQt}. When \code{lambda_global} is zero \code{K_global} is the
 #'   (pseudo-)inverse of \code{R} times \code{Qt}; otherwise ridge
-#'   regularization is applied.
+#'   regularization is applied. When \code{lambda_global} \code{>} 0, the
+#'   \code{RtR} component already has \code{lambda_global} added to its
+#'   diagonal.
 #' @export
 build_projector <- function(X_theta, lambda_global = 0, diagnostics = FALSE,
                            pivot = TRUE) {


### PR DESCRIPTION
## Summary
- clarify in `build_projector()` documentation that `RtR` already includes `lambda_global` when a positive ridge penalty is used
- attempted to regenerate documentation via `devtools::document()`

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d66f6ee4832daa5b8a2d32e6cda8