### PR TITLE
Handle NA collapse

### DIFF
--- a/R/collapse_beta.R
+++ b/R/collapse_beta.R
@@ -35,6 +35,19 @@ collapse_beta <- function(Z_sl_raw, N_trials,
             K_hrf_bases > 0,
             nrow(Z_sl_raw) == N_trials * K_hrf_bases)
 
+  if (anyNA(Z_sl_raw)) {
+    warning("Z_sl_raw contains missing values")
+    V_sl <- ncol(Z_sl_raw)
+    A_vec <- rep(NA_real_, N_trials * V_sl)
+    dim(A_vec) <- c(N_trials, V_sl)
+    w_sl <- rep(1 / sqrt(K_hrf_bases), K_hrf_bases)
+    diag_list <- NULL
+    if (diagnostics) {
+      diag_list <- cap_diagnostics(list(method = method, w_sl = w_sl))
+    }
+    return(list(A_sl = A_vec, w_sl = w_sl, diag_data = diag_list))
+  }
+
 
   V_sl <- ncol(Z_sl_raw)
   Zmat <- matrix(Z_sl_raw, K_hrf_bases, N_trials * V_sl, byrow = FALSE)

--- a/tests/testthat/test-adaptive-collapse.R
+++ b/tests/testthat/test-adaptive-collapse.R
@@ -179,3 +179,31 @@ test_that("adaptive_ridge_projector skips EB when T_obs <= m", {
   expect_true(is.na(res$diag_data$s_b_sq))
 })
 
+test_that("collapse_beta rss warns and returns NA on NA input", {
+  N_trials <- 2
+  K <- 2
+  Z_sl_raw <- matrix(c(1, NA, 3, 4), nrow = N_trials * K)
+  expect_warning(res <- collapse_beta(Z_sl_raw, N_trials, K,
+                                      method = "rss", diagnostics = TRUE),
+                 "Z_sl_raw contains")
+  expect_true(all(is.na(res$A_sl)))
+  expect_equal(res$w_sl, rep(1 / sqrt(K), K))
+  expect_false(is.null(res$diag_data))
+})
+
+test_that("collapse_beta optim warns and returns NA on NA input", {
+  N_trials <- 2
+  K <- 2
+  Z_sl_raw <- matrix(c(1, NA, 3, 4), nrow = N_trials * K)
+  labels <- c(1, 0)
+  clf <- function(A, y) list(loss = 0, grad = matrix(0, nrow = N_trials, ncol = ncol(A)))
+  expect_warning(res <- collapse_beta(Z_sl_raw, N_trials, K,
+                                      method = "optim", diagnostics = TRUE,
+                                      labels_for_w_optim = labels,
+                                      classifier_for_w_optim = clf),
+                 "Z_sl_raw contains")
+  expect_true(all(is.na(res$A_sl)))
+  expect_equal(res$w_sl, rep(1 / sqrt(K), K))
+  expect_false(is.null(res$diag_data))
+})
+


### PR DESCRIPTION
## Summary
- warn and return `NA` from `collapse_beta()` when `Z_sl_raw` has NA
- add tests for `rss` and `optim` NA handling

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d696241c832da35dfcec0a364efb