### PR TITLE
Update collapse_beta docs

### DIFF
--- a/R/collapse_beta.R
+++ b/R/collapse_beta.R
@@ -4,6 +4,7 @@
 #' feature patterns. Supports the default root-sum-square (`method = "rss"`),
 #' an SNR-optimal principal component (`method = "pc"`), and optional
 #' supervised optimization of the collapse weights (`method = "optim"`).
+#' The resulting weights `w_sl` are normalized to unit length.
 #'
 #' @param Z_sl_raw Matrix of raw projected coefficients with
 #'   `(N_trials * K_hrf_bases)` rows and `V_sl` columns.
@@ -16,10 +17,10 @@
 #' @param classifier_for_w_optim Function returning loss and gradient given
 #'   `A_sl` and labels when `method = "optim"`.
 #' @param optim_w_params List of controls passed to `stats::optim` when
-#'   `method = "optim"`.
+#'   `method = "optim"`. The `maxit` element defaults to 5.
 #' @return A list with elements:
 #'   \item{A_sl}{Collapsed trial pattern matrix `N_trials x V_sl`.}
-#'   \item{w_sl}{Collapse weights used for combining HRF bases.}
+#'   \item{w_sl}{Normalized collapse weights (unit length) used for combining HRF bases.}
 #'   \item{diag_data}{Optional diagnostics.}
 #' @export
 collapse_beta <- function(Z_sl_raw, N_trials,


### PR DESCRIPTION
## Summary
- note that `w_sl` is normalized to unit length
- document default of `optim_w_params$maxit`
- (attempted) rebuild of package documentation

## Testing
- `R -q -e "devtools::document()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d699aa58832d93df7766c31b4db1