### PR TITLE
Validate inputs for hrf_basis_spmg3_theta

### DIFF
--- a/R/hrf_basis_spmg3_theta.R
+++ b/R/hrf_basis_spmg3_theta.R
@@ -3,10 +3,11 @@
 #' Generates a simple SPMG3-style HRF basis with optional scaling of
 #' the canonical delay and dispersion parameters via `theta`.
 #'
-#' @param theta Numeric vector of length 1 or 2 controlling delay and
-#'   dispersion scaling. If of length 1, the same value is used for both
-#'   delay and dispersion. Defaults to `c(1, 1)`.
+#' @param theta Numeric vector controlling delay and dispersion scaling.
+#'   Must be numeric and of length 1 or 2. If of length 1, the same value
+#'   is used for both delay and dispersion. Defaults to `c(1, 1)`.
 #' @param t Numeric vector of time points at which to evaluate the basis.
+#'   Must be strictly increasing with at least one element.
 #'
 #' @return Matrix with length(t) rows and 3 columns: canonical HRF,
 #'   temporal derivative, and dispersion derivative.
@@ -16,6 +17,13 @@
 #' differences are applied at the boundaries.
 #' @export
 hrf_basis_spmg3_theta <- function(theta = c(1, 1), t) {
+  if (!is.numeric(theta) || !(length(theta) %in% c(1, 2))) {
+    stop("theta must be numeric of length 1 or 2")
+  }
+  if (!is.numeric(t) || length(t) < 1 || any(diff(t) <= 0)) {
+    stop("t must be a numeric, strictly increasing vector with at least one element")
+  }
+
   delay_scale <- theta[1]
   disp_scale <- if (length(theta) >= 2) theta[2] else theta[1]
 

--- a/tests/testthat/test-hrf-basis-spmg3-theta.R
+++ b/tests/testthat/test-hrf-basis-spmg3-theta.R
@@ -47,3 +47,22 @@ test_that("derivatives behave as expected for simple t", {
 
   expect_equal(B, expected)
 })
+
+test_that("invalid theta arguments error", {
+  t <- 0:2
+  expect_error(hrf_basis_spmg3_theta(theta = "a", t = t),
+               "theta must be numeric")
+  expect_error(hrf_basis_spmg3_theta(theta = c(1, 2, 3), t = t),
+               "length 1 or 2")
+})
+
+test_that("invalid t arguments error", {
+  expect_error(hrf_basis_spmg3_theta(t = c(1, 1)),
+               "strictly increasing")
+  expect_error(hrf_basis_spmg3_theta(t = c(2, 1)),
+               "strictly increasing")
+  expect_error(hrf_basis_spmg3_theta(t = numeric(0)),
+               "at least one element")
+  expect_error(hrf_basis_spmg3_theta(t = "a"),
+               "numeric")
+})


### PR DESCRIPTION
## Summary
- validate inputs for `hrf_basis_spmg3_theta`
- document new input requirements
- test that invalid parameters generate errors

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6a83a68832d84426a64a282238f