### PR TITLE
Store HRF maximum before normalization

### DIFF
--- a/R/hrf_basis_spmg3_theta.R
+++ b/R/hrf_basis_spmg3_theta.R
@@ -26,7 +26,8 @@ hrf_basis_spmg3_theta <- function(theta = c(1, 1), t) {
 
   hrf <- stats::dgamma(t, shape = p1, rate = d1) -
     0.35 * stats::dgamma(t, shape = p2, rate = d2)
-  if (max(hrf) != 0) hrf <- hrf / max(hrf)
+  hrf_max <- max(hrf)
+  if (hrf_max != 0) hrf <- hrf / hrf_max
 
   n <- length(hrf)
   deriv1 <- numeric(n)

--- a/inst/examples/example_build_design_matrix.R
+++ b/inst/examples/example_build_design_matrix.R
@@ -49,7 +49,8 @@ simple_hrf_func <- function(theta_params, time_vector) {
   # theta_params[1] controls the peak time
   peak_time <- theta_params[1]
   hrf <- dnorm(time_vector, mean = peak_time, sd = 1)
-  hrf <- hrf / max(hrf)  # Normalize
+  hrf_max <- max(hrf)
+  hrf <- hrf / hrf_max  # Normalize
   
   # Return as matrix (length x 1 basis)
   matrix(hrf, ncol = 1)

--- a/inst/examples/example_optimize_hrf_mvpa.R
+++ b/inst/examples/example_optimize_hrf_mvpa.R
@@ -44,7 +44,8 @@ hrf_basis_spmg3_theta <- function(theta_params, time_vector) {
   # theta_params[1] = time to peak
   peak <- theta_params[1]
   hrf <- dnorm(time_vector, mean = peak, sd = 1.5)
-  matrix(hrf / max(hrf), ncol = 1)
+  hrf_max <- max(hrf)
+  matrix(hrf / hrf_max, ncol = 1)
 }
 
 # Inner CV function: simple classification accuracy
@@ -108,7 +109,8 @@ hrf_two_param <- function(theta_params, time_vector) {
   
   # Double gamma HRF
   hrf_main <- dgamma(time_vector, shape = peak/width, scale = width)
-  hrf_main <- hrf_main / max(hrf_main)
+  hrf_max <- max(hrf_main)
+  hrf_main <- hrf_main / hrf_max
   
   # Derivative
   hrf_deriv <- c(0, diff(hrf_main))

--- a/inst/examples/example_run_searchlight_projected.R
+++ b/inst/examples/example_run_searchlight_projected.R
@@ -93,7 +93,8 @@ flexible_hrf <- function(theta_params, time_vector) {
   
   # Gamma-like HRF
   hrf_main <- dgamma(time_vector, shape = ttp/width, scale = width)
-  hrf_main <- hrf_main / max(hrf_main)
+  hrf_max <- max(hrf_main)
+  hrf_main <- hrf_main / hrf_max
   
   # Simple derivative
   hrf_deriv <- c(0, diff(hrf_main))

--- a/tests/testthat/test-collapse-optimization.R
+++ b/tests/testthat/test-collapse-optimization.R
@@ -246,7 +246,8 @@ test_that("HRF optimization improves MVPA performance on appropriate problems", 
     # True HRF shape
     t_hrf <- seq(0, 20, by = TR)
     hrf <- dgamma(t_hrf, shape = peak_time, rate = 1)
-    hrf <- hrf / max(hrf)
+    hrf_max <- max(hrf)
+    hrf <- hrf / hrf_max
     
     # Generate signal
     for (trial in 1:n_trials) {
@@ -276,10 +277,11 @@ test_that("HRF optimization improves MVPA performance on appropriate problems", 
   # Define flexible HRF basis function  
   flexible_hrf <- function(theta_params, time_vector) {
     peak <- theta_params[1]
-    
+
     # Main function
     hrf_main <- dgamma(time_vector, shape = peak, rate = 1)
-    if (max(hrf_main) > 0) hrf_main <- hrf_main / max(hrf_main)
+    hrf_max <- max(hrf_main)
+    if (hrf_max > 0) hrf_main <- hrf_main / hrf_max
     
     # Derivative
     hrf_deriv <- c(0, diff(hrf_main))

--- a/tests/testthat/test-hrf-basis-spmg3-theta.R
+++ b/tests/testthat/test-hrf-basis-spmg3-theta.R
@@ -22,7 +22,8 @@ test_that("derivatives behave as expected for simple t", {
   d2 <- 1
   hrf <- stats::dgamma(t, shape = p1, rate = d1) -
     0.35 * stats::dgamma(t, shape = p2, rate = d2)
-  if (max(hrf) != 0) hrf <- hrf / max(hrf)
+  hrf_max <- max(hrf)
+  if (hrf_max != 0) hrf <- hrf / hrf_max
   n <- length(hrf)
   deriv1 <- numeric(n)
   deriv2 <- numeric(n)

--- a/vignettes/getting-started-with-fmriproj.Rmd
+++ b/vignettes/getting-started-with-fmriproj.Rmd
@@ -243,7 +243,8 @@ flexible_hrf <- function(theta, time_points) {
   
   # Generate double-gamma HRF
   hrf <- dgamma(time_points, shape = peak_time/width, scale = width)
-  hrf <- hrf / max(hrf)
+  hrf_max <- max(hrf)
+  hrf <- hrf / hrf_max
   
   # Add derivative
   hrf_deriv <- c(0, diff(hrf))


### PR DESCRIPTION
## Summary
- compute `max(hrf)` once in `hrf_basis_spmg3_theta`
- propagate this approach to examples, tests, and vignette

## Testing
- `Rscript --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6aa61c8832d8cf873278699ecc6