### PR TITLE
Simplify HRF basis derivative tests

### DIFF
--- a/tests/testthat/test-hrf-basis-spmg3-theta.R
+++ b/tests/testthat/test-hrf-basis-spmg3-theta.R
@@ -16,34 +16,35 @@ test_that("derivatives behave as expected for simple t", {
   t <- 0:4
   B <- hrf_basis_spmg3_theta(t = t)
 
-  p1 <- 6
-  p2 <- 16
-  d1 <- 1
-  d2 <- 1
-  hrf <- stats::dgamma(t, shape = p1, rate = d1) -
-    0.35 * stats::dgamma(t, shape = p2, rate = d2)
-  if (max(hrf) != 0) hrf <- hrf / max(hrf)
-  n <- length(hrf)
-  deriv1 <- numeric(n)
-  deriv2 <- numeric(n)
+  canonical <- B[, 1]
+  deriv1 <- B[, 2]
+  deriv2 <- B[, 3]
 
-  if (n > 1) {
-    deriv1[1] <- (hrf[2] - hrf[1]) / (t[2] - t[1])
-    deriv1[n] <- (hrf[n] - hrf[n - 1]) / (t[n] - t[n - 1])
-    if (n > 2) {
-      deriv1[2:(n - 1)] <- (hrf[3:n] - hrf[1:(n - 2)]) /
-        (t[3:n] - t[1:(n - 2)])
-    }
+  # First derivative at a few points
+  expect_equal(
+    deriv1[1],
+    (canonical[2] - canonical[1]) / (t[2] - t[1])
+  )
+  expect_equal(
+    deriv1[3],
+    (canonical[4] - canonical[2]) / (t[4] - t[2])
+  )
+  expect_equal(
+    deriv1[5],
+    (canonical[5] - canonical[4]) / (t[5] - t[4])
+  )
 
-    deriv2[1] <- (deriv1[2] - deriv1[1]) / (t[2] - t[1])
-    deriv2[n] <- (deriv1[n] - deriv1[n - 1]) / (t[n] - t[n - 1])
-    if (n > 2) {
-      deriv2[2:(n - 1)] <- (deriv1[3:n] - deriv1[1:(n - 2)]) /
-        (t[3:n] - t[1:(n - 2)])
-    }
-  }
-
-  expected <- cbind(hrf, deriv1, deriv2)
-
-  expect_equal(B, expected)
+  # Second derivative at the same points
+  expect_equal(
+    deriv2[1],
+    (deriv1[2] - deriv1[1]) / (t[2] - t[1])
+  )
+  expect_equal(
+    deriv2[3],
+    (deriv1[4] - deriv1[2]) / (t[4] - t[2])
+  )
+  expect_equal(
+    deriv2[5],
+    (deriv1[5] - deriv1[4]) / (t[5] - t[4])
+  )
 })


### PR DESCRIPTION
## Summary
- replace duplicated derivative implementation in tests with small property checks

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6ac75ec832d9e4f3e1df01008c8