### PR TITLE
Add central_diff utility and refactor HRF basis

### DIFF
--- a/R/central_diff.R
+++ b/R/central_diff.R
@@ -1,0 +1,32 @@
+#' Central differences with boundary handling
+#'
+#' Computes derivatives of a numeric vector using a central difference scheme
+#' that supports irregular spacing. Forward and backward differences are used
+#' at the boundaries.
+#'
+#' @param y Numeric vector to differentiate.
+#' @param t Numeric vector of sampling points corresponding to `y`.
+#' @param order Derivative order to compute. Either 1 or 2. Defaults to 1.
+#'
+#' @return Numeric vector of the same length as `y` containing the derivative.
+#' @keywords internal
+central_diff <- function(y, t, order = 1) {
+  stopifnot(length(y) == length(t))
+  n <- length(y)
+  if (n <= 1) return(numeric(n))
+
+  deriv <- numeric(n)
+  deriv[1] <- (y[2] - y[1]) / (t[2] - t[1])
+  deriv[n] <- (y[n] - y[n - 1]) / (t[n] - t[n - 1])
+  if (n > 2) {
+    deriv[2:(n - 1)] <- (y[3:n] - y[1:(n - 2)]) / (t[3:n] - t[1:(n - 2)])
+  }
+
+  if (order == 1) {
+    deriv
+  } else if (order == 2) {
+    central_diff(deriv, t, order = 1)
+  } else {
+    stop("order must be 1 or 2")
+  }
+}

--- a/R/hrf_basis_spmg3_theta.R
+++ b/R/hrf_basis_spmg3_theta.R
@@ -28,25 +28,8 @@ hrf_basis_spmg3_theta <- function(theta = c(1, 1), t) {
     0.35 * stats::dgamma(t, shape = p2, rate = d2)
   if (max(hrf) != 0) hrf <- hrf / max(hrf)
 
-  n <- length(hrf)
-  deriv1 <- numeric(n)
-  deriv2 <- numeric(n)
-
-  if (n > 1) {
-    deriv1[1] <- (hrf[2] - hrf[1]) / (t[2] - t[1])
-    deriv1[n] <- (hrf[n] - hrf[n - 1]) / (t[n] - t[n - 1])
-    if (n > 2) {
-      deriv1[2:(n - 1)] <- (hrf[3:n] - hrf[1:(n - 2)]) /
-        (t[3:n] - t[1:(n - 2)])
-    }
-
-    deriv2[1] <- (deriv1[2] - deriv1[1]) / (t[2] - t[1])
-    deriv2[n] <- (deriv1[n] - deriv1[n - 1]) / (t[n] - t[n - 1])
-    if (n > 2) {
-      deriv2[2:(n - 1)] <- (deriv1[3:n] - deriv1[1:(n - 2)]) /
-        (t[3:n] - t[1:(n - 2)])
-    }
-  }
+  deriv1 <- central_diff(hrf, t)
+  deriv2 <- central_diff(hrf, t, order = 2)
 
   cbind(hrf, deriv1, deriv2)
 }

--- a/tests/testthat/test-central-diff.R
+++ b/tests/testthat/test-central-diff.R
@@ -1,0 +1,22 @@
+context("central_diff")
+
+test_that("first derivative matches manual difference", {
+  t <- 0:4
+  y <- t^2
+  manual <- numeric(length(y))
+  manual[1] <- (y[2] - y[1]) / (t[2] - t[1])
+  manual[length(y)] <- (y[length(y)] - y[length(y)-1]) / (t[length(y)] - t[length(y)-1])
+  if (length(y) > 2) {
+    manual[2:(length(y)-1)] <- (y[3:length(y)] - y[1:(length(y)-2)]) /
+      (t[3:length(y)] - t[1:(length(y)-2)])
+  }
+  expect_equal(central_diff(y, t), manual)
+})
+
+test_that("second derivative computed recursively", {
+  t <- 0:4
+  y <- t^3
+  d1 <- central_diff(y, t)
+  manual_d2 <- central_diff(d1, t)
+  expect_equal(central_diff(y, t, order = 2), manual_d2)
+})

--- a/tests/testthat/test-hrf-basis-spmg3-theta.R
+++ b/tests/testthat/test-hrf-basis-spmg3-theta.R
@@ -23,26 +23,8 @@ test_that("derivatives behave as expected for simple t", {
   hrf <- stats::dgamma(t, shape = p1, rate = d1) -
     0.35 * stats::dgamma(t, shape = p2, rate = d2)
   if (max(hrf) != 0) hrf <- hrf / max(hrf)
-  n <- length(hrf)
-  deriv1 <- numeric(n)
-  deriv2 <- numeric(n)
-
-  if (n > 1) {
-    deriv1[1] <- (hrf[2] - hrf[1]) / (t[2] - t[1])
-    deriv1[n] <- (hrf[n] - hrf[n - 1]) / (t[n] - t[n - 1])
-    if (n > 2) {
-      deriv1[2:(n - 1)] <- (hrf[3:n] - hrf[1:(n - 2)]) /
-        (t[3:n] - t[1:(n - 2)])
-    }
-
-    deriv2[1] <- (deriv1[2] - deriv1[1]) / (t[2] - t[1])
-    deriv2[n] <- (deriv1[n] - deriv1[n - 1]) / (t[n] - t[n - 1])
-    if (n > 2) {
-      deriv2[2:(n - 1)] <- (deriv1[3:n] - deriv1[1:(n - 2)]) /
-        (t[3:n] - t[1:(n - 2)])
-    }
-  }
-
+  deriv1 <- central_diff(hrf, t)
+  deriv2 <- central_diff(hrf, t, order = 2)
   expected <- cbind(hrf, deriv1, deriv2)
 
   expect_equal(B, expected)


### PR DESCRIPTION
## Summary
- create `central_diff()` helper to calculate finite differences
- refactor `hrf_basis_spmg3_theta()` to use the helper
- add tests for `central_diff`
- update HRF basis tests

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6ae3238832db0926bdeeaf316e5