### PR TITLE
Optimize finite difference gradient

### DIFF
--- a/R/optimize_joint_hrf_mvpa.R
+++ b/R/optimize_joint_hrf_mvpa.R
@@ -65,7 +65,7 @@ optimize_hrf_mvpa <- function(theta_init,
   trace_env$rows <- list()
 
 
-  loss_fn_theta <- function(theta) {
+  loss_fn_theta <- function(theta, record = TRUE) {
     X_obj <- build_design_matrix(event_model,
                                  hrf_basis_func = hrf_basis_func,
                                  theta_params = theta,
@@ -98,7 +98,7 @@ optimize_hrf_mvpa <- function(theta_init,
       stop("`inner_cv_fn` must return a finite numeric scalar 'loss'.", call. = FALSE)
     }
 
-    if (isTRUE(diagnostics)) {
+    if (isTRUE(record) && isTRUE(diagnostics)) {
       row <- c(loss = loss,
                setNames(as.numeric(theta),
                         paste0("theta", seq_along(theta))))
@@ -111,10 +111,11 @@ optimize_hrf_mvpa <- function(theta_init,
   if (use_fd_grad) {
     grad_fn <- function(th) {
       eps <- 1e-6
+      base_loss <- loss_fn_theta(th, record = FALSE)
       sapply(seq_along(th), function(i) {
         th_eps <- th
         th_eps[i] <- th_eps[i] + eps
-        (loss_fn_theta(th_eps) - loss_fn_theta(th)) / eps
+        (loss_fn_theta(th_eps, record = FALSE) - base_loss) / eps
       })
     }
   }


### PR DESCRIPTION
## Summary
- tweak `loss_fn_theta` to accept a `record` argument
- compute the base loss once when calculating finite difference gradients

## Testing
- `npm test` *(fails: Could not read package.json)*
- `R CMD check` *(fails: R: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6c124c4832da69b843b353525fa