### PR TITLE
Add record flag for optimization tracing

### DIFF
--- a/R/optimize_joint_hrf_mvpa.R
+++ b/R/optimize_joint_hrf_mvpa.R
@@ -65,7 +65,7 @@ optimize_hrf_mvpa <- function(theta_init,
   trace_env$rows <- list()
 
 
-  loss_fn_theta <- function(theta) {
+  loss_fn_theta <- function(theta, record = TRUE) {
     X_obj <- build_design_matrix(event_model,
                                  hrf_basis_func = hrf_basis_func,
                                  theta_params = theta,
@@ -98,7 +98,7 @@ optimize_hrf_mvpa <- function(theta_init,
       stop("`inner_cv_fn` must return a finite numeric scalar 'loss'.", call. = FALSE)
     }
 
-    if (isTRUE(diagnostics)) {
+    if (isTRUE(diagnostics) && record) {
       row <- c(loss = loss,
                setNames(as.numeric(theta),
                         paste0("theta", seq_along(theta))))
@@ -114,7 +114,8 @@ optimize_hrf_mvpa <- function(theta_init,
       sapply(seq_along(th), function(i) {
         th_eps <- th
         th_eps[i] <- th_eps[i] + eps
-        (loss_fn_theta(th_eps) - loss_fn_theta(th)) / eps
+        (loss_fn_theta(th_eps, record = FALSE) -
+           loss_fn_theta(th, record = FALSE)) / eps
       })
     }
   }


### PR DESCRIPTION
## Summary
- support suppressing diagnostics when evaluating loss
- skip tracing in finite-difference gradient calculation

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844d6c51550832d8c3499126d05d810