### PR TITLE
Fix merge conflict markers in lacunae tests

### DIFF
--- a/tests/testthat/test-additional-lacunae.R
+++ b/tests/testthat/test-additional-lacunae.R
@@ -138,17 +138,10 @@ test_that("optimize_hrf_mvpa validates arguments", {
                       optim_method = "Nelder-Mead"),
     "Y must be a numeric matrix"
   )
-})
-
-test_that("optimize_hrf_mvpa validates optim_method", {
-  Y <- matrix(1, nrow = 2, ncol = 1)
-  em <- list(onsets = c(0L), n_time = 2L, basis_length = 1L)
-  basis_fun <- function(theta, t) matrix(theta[1], nrow = length(t), ncol = 1)
   expect_error(
     optimize_hrf_mvpa(theta_init = c(1),
                       Y = Y,
                       event_model = em,
-
                       inner_cv_fn = 5,
                       hrf_basis_func = basis_fun,
                       optim_method = "Nelder-Mead"),
@@ -174,7 +167,17 @@ test_that("optimize_hrf_mvpa validates optim_method", {
                       hrf_basis_func = basis_fun,
                       optim_method = "Nelder-Mead"),
     "event_model missing required fields"
-###=======
+  )
+})
+
+test_that("optimize_hrf_mvpa validates optim_method", {
+  Y <- matrix(1, nrow = 2, ncol = 1)
+  em <- list(onsets = c(0L), n_time = 2L, basis_length = 1L)
+  basis_fun <- function(theta, t) matrix(theta[1], nrow = length(t), ncol = 1)
+  expect_error(
+    optimize_hrf_mvpa(theta_init = c(1),
+                      Y = Y,
+                      event_model = em,
                       inner_cv_fn = sum,
                       hrf_basis_func = basis_fun,
                       optim_method = "bogus"),
@@ -196,7 +199,5 @@ test_that("optimize_hrf_mvpa warns when bounds ignored", {
                       lower = 0,
                       upper = 1),
     "ignored"
-##>>>>>>> main
   )
 })
-


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in `test-additional-lacunae.R`
- restore tests for `optimize_hrf_mvpa` argument validation and warnings

## Testing
- `R -q -e "devtools::test()"` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844dbcc6d00832db7d4dbf4461170e6