### PR TITLE
Add tests for chunked projection and training wrapper

### DIFF
--- a/tests/testthat/test-chunked-projection.R
+++ b/tests/testthat/test-chunked-projection.R
@@ -1,0 +1,29 @@
+context("chunked projection dataset")
+
+test_that("wrap_as_chunked_projecting_dataset caches results", {
+  Y <- matrix(seq_len(40), nrow = 4) # 4 timepoints x 10 voxels
+  counter <- 0
+  proj_fun <- function(data) {
+    counter <<- counter + 1
+    data + 1
+  }
+  ds <- wrap_as_chunked_projecting_dataset(
+    Y, proj_fun,
+    original_dataset = list(nfeatures = ncol(Y)),
+    chunk_size = 5, cache_results = TRUE
+  )
+
+  full1 <- ds$get_data()
+  expect_equal(counter, ceiling(ncol(Y) / 5))
+  expect_equal(full1, Y + 1)
+
+  counter_before <- counter
+  sub1 <- ds$get_data(indices = 1:10)
+  expect_equal(counter, counter_before)
+  expect_equal(sub1, full1[, 1:10])
+
+  ds$clear_cache()
+  sub2 <- ds$get_data(indices = 1:5)
+  expect_equal(counter, counter_before + 1)
+  expect_equal(sub2, full1[, 1:5])
+})

--- a/tests/testthat/test-recommend-chunk-size.R
+++ b/tests/testthat/test-recommend-chunk-size.R
@@ -1,0 +1,12 @@
+context("recommend_chunk_size")
+
+test_that("recommend_chunk_size respects bounds and messages", {
+  # Set small memory limit so chunk size floored to 100
+  expect_message(cs <- recommend_chunk_size(100, 1000, 50, memory_limit_gb = 0.0001),
+                 "Recommended chunk size")
+  expect_equal(cs, 100)
+
+  # Large memory should cap at n_voxels
+  cs2 <- recommend_chunk_size(10, 200, 5, memory_limit_gb = 1000)
+  expect_equal(cs2, 200)
+})

--- a/tests/testthat/test-train-model-wrapper.R
+++ b/tests/testthat/test-train-model-wrapper.R
@@ -1,0 +1,39 @@
+context("train_model.mvpa_model")
+
+mvpa_model_obj <- structure(list(dummy = TRUE), class = "mvpa_model")
+X <- matrix(rnorm(20), ncol = 4)
+proj_fun <- function(m) m * 2
+
+
+test_that("train_model.mvpa_model errors when rMVPA missing", {
+  if ("rMVPA" %in% loadedNamespaces()) detach("package:rMVPA", unload = TRUE, character.only = TRUE)
+  expect_error(train_model.mvpa_model(mvpa_model_obj, X), "rMVPA package required")
+})
+
+
+test_that("projection_function attribute is applied when rMVPA present", {
+  skip_if_not_installed("methods") # ensure base environment
+
+  fake_env <- new.env()
+  X_seen <- NULL
+  fake_env$train_model.mvpa_model <- function(obj, X, ...) { X_seen <<- X; list(ok = TRUE) }
+
+  env <- environment(train_model.mvpa_model)
+  orig_require <- env$requireNamespace
+  orig_asNamespace <- env$asNamespace
+  orig_getS3method <- env$getS3method
+
+  env$requireNamespace <- function(pkg, quietly = TRUE) TRUE
+  env$asNamespace <- function(pkg) fake_env
+  env$getS3method <- function(fn, class, envir = fake_env) fake_env$train_model.mvpa_model
+
+  attr(X, "projection_function") <- proj_fun
+  result <- train_model.mvpa_model(mvpa_model_obj, X)
+
+  env$requireNamespace <- orig_require
+  env$asNamespace <- orig_asNamespace
+  env$getS3method <- orig_getS3method
+
+  expect_equal(X_seen, proj_fun(X))
+  expect_true(result$ok)
+})


### PR DESCRIPTION
## Summary
- expand coverage for chunked projection logic
- validate recommend_chunk_size bounds
- test train_model wrapper behavior with and without rMVPA

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e5fd0ef0832d95f61f27d2a91dd6